### PR TITLE
🚀 Release 0.5.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v0.5.22 (09/06/21)
+
+### Bug Fixes
+
+* **ci:** testing ([b4b09ab](https://github.com/seasketch/next/commit/b4b09abe96886bfdfd9a450f0741854b457bc0b4))
+* **ci:** testing ([0e21042](https://github.com/seasketch/next/commit/0e21042cff22fca453c3324b1a7a698078a91009))
+
+
+
+
 # v0.5.21 (09/06/21)
 
 ### Bug Fixes

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.22](https://github.com/seasketch/next/compare/client@0.5.20...client@0.5.22) (2021-09-06)
+
+
+### Bug Fixes
+
+* **ci:** testing ([b4b09ab](https://github.com/seasketch/next/commit/b4b09abe96886bfdfd9a450f0741854b457bc0b4))
+* **ci:** testing ([0e21042](https://github.com/seasketch/next/commit/0e21042cff22fca453c3324b1a7a698078a91009))
+
+
+
+
+
 ## [0.5.21](https://github.com/seasketch/next/compare/client@0.5.20...client@0.5.21) (2021-09-06)
 
 

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "client",
-	"version": "0.5.21",
+	"version": "0.5.22",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.5.21",
+  "version": "0.5.22",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.3.8",


### PR DESCRIPTION
Approving this pull request will start the production deployment pipeline.


## Updated Packages

| package name | updated version |
|--------------|-----------------|
| client | 0.5.21 → 0.5.22 |


## Changelog

The changelog includes all [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Review the [full commit log](https://github.com/seasketch/next/compare/v0.5.20...b4b09abe96886bfdfd9a450f0741854b457bc0b4) for commits that don't follow this convention.

### Bug Fixes

* **ci:** testing ([b4b09ab](https://github.com/seasketch/next/commit/b4b09abe96886bfdfd9a450f0741854b457bc0b4))
* **ci:** testing ([0e21042](https://github.com/seasketch/next/commit/0e21042cff22fca453c3324b1a7a698078a91009))