### PR TITLE
🚀 Release 0.5.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.5.27 (09/06/21)
+
+### Bug Fixes
+
+* **ci:** testing ([5c75892](https://github.com/seasketch/next/commit/5c758924300d5d957d1cda9fbe85c6efb80568af))
+
+
+
+
 # v0.5.26 (09/06/21)
 
 ### Bug Fixes

--- a/packages/client/CHANGELOG.md
+++ b/packages/client/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.5.27](https://github.com/seasketch/next/compare/client@0.5.26...client@0.5.27) (2021-09-06)
+
+
+### Bug Fixes
+
+* **ci:** testing ([5c75892](https://github.com/seasketch/next/commit/5c758924300d5d957d1cda9fbe85c6efb80568af))
+
+
+
+
+
 ## [0.5.26](https://github.com/seasketch/next/compare/client@0.5.25...client@0.5.26) (2021-09-06)
 
 

--- a/packages/client/package-lock.json
+++ b/packages/client/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "client",
-	"version": "0.5.26",
+	"version": "0.5.27",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client",
-  "version": "0.5.26",
+  "version": "0.5.27",
   "private": true,
   "dependencies": {
     "@apollo/client": "^3.3.8",


### PR DESCRIPTION
Approving this pull request will start the production deployment pipeline.


## Updated Packages

| package name | updated version |
|--------------|-----------------|
| client | 0.5.26 → 0.5.27 |


## Changelog

The changelog includes all [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/). Review the [full commit log](https://github.com/seasketch/next/compare/v0.5.26...5c758924300d5d957d1cda9fbe85c6efb80568af) for commits that don't follow this convention.

### Bug Fixes

* **ci:** testing ([5c75892](https://github.com/seasketch/next/commit/5c758924300d5d957d1cda9fbe85c6efb80568af))