### PR TITLE
Ensure parent collection updatedAt property... gets updated

### DIFF
--- a/packages/api/generated-schema-clean.gql
+++ b/packages/api/generated-schema-clean.gql
@@ -875,6 +875,11 @@ type CopySketchTocItemResults {
   folders: [SketchFolder!]
   parentId: Int!
   sketches: [Sketch!]
+
+  """
+  Returns the parent collection (if exists) so that the client can select an updated updatedAt
+  """
+  updatedCollection: Sketch
 }
 
 """All input for the create `Basemap` mutation."""
@@ -4052,6 +4057,11 @@ type DeleteSketchPayload {
 
   """Reads a single `User` that is related to this `Sketch`."""
   user: User
+}
+
+type DeleteSketchTocItemsResults {
+  deletedItems: [String!]!
+  updatedCollections: [Sketch]!
 }
 
 """All input for the `deleteSurveyByNodeId` mutation."""
@@ -7353,6 +7363,15 @@ type Mutation {
     input: DeleteSketchFolderByNodeIdInput!
   ): DeleteSketchFolderPayload
 
+  """
+  Deletes one or more Sketch or SketchFolders
+  
+  Returns an updatedCollections property which should be used to update the
+  updatedAt property on related collections so that correct cache keys are
+  used when requesting reports.
+  """
+  deleteSketchTocItems(items: [UpdateTocItemParentInput]!): DeleteSketchTocItemsResults
+
   """Deletes a single `Survey` using a unique key."""
   deleteSurvey(
     """
@@ -8252,6 +8271,11 @@ type Mutation {
   function again on userGeom. This ensures the value conforms to the
   project's rules, and also benefits the user in that they need not submit
   a huge geometry to the server.
+  
+  When updating a sketch, be sure to use the Sketch.parentCollection
+  association to update the client graphql cache with an up to date
+  updatedAt timestamp. This will ensure a correct cache key is used when
+  requesting collection reports.
   """
   updateSketch(
     id: Int!
@@ -8315,6 +8339,17 @@ type Mutation {
     """
     input: UpdateSketchParentInput!
   ): UpdateSketchParentPayload
+
+  """
+  Create to respond to drag & drop actions in the sketch table of contents.
+  Can assign a folder_id or collection_id to one or multiple Sketches or
+  SketchFolders.
+  
+  Returns an updatedCollections property which should be used to update the
+  updatedAt property on related collections so that correct cache keys are
+  used when requesting reports.
+  """
+  updateSketchTocItemParent(collectionId: Int, folderId: Int, tocItems: [UpdateTocItemParentInput]!): UpdateSketchTocItemParentResults
 
   """Updates a single `Survey` using a unique key and a patch."""
   updateSurvey(
@@ -10048,6 +10083,7 @@ type Query implements Node {
   We return "dev" if build cannot be determined from deployment environment.
   """
   build: String!
+  camelCase(snakeCase: String): String
   collectTextFromProsemirrorBody(body: JSON): String
   collectTextFromProsemirrorBodyForLabel(body: JSON): String
   communityGuideline(projectId: Int!): CommunityGuideline
@@ -10298,6 +10334,7 @@ type Query implements Node {
     """
     nodeId: ID!
   ): InviteEmail
+  lcfirst(word: String): String
 
   """
   Access the current session's User. The user is determined by the access token embedded in the `Authorization` header.
@@ -10745,6 +10782,7 @@ type Query implements Node {
     offset: Int
   ): [SketchClass!]
   tilebbox(srid: Int, x: Int, y: Int, z: Int): GeometryInterface
+  toGraphqlId(id: Int, type: String): String
   topic(id: Int!): Topic
 
   """Reads a single `Topic` using its globally unique `ID`."""
@@ -14511,6 +14549,12 @@ type UpdateSketchParentPayload {
   user: User
 }
 
+type UpdateSketchTocItemParentResults {
+  folders: [SketchFolder]!
+  sketches: [Sketch]!
+  updatedCollections: [Sketch]!
+}
+
 """All input for the `updateSurveyByNodeId` mutation."""
 input UpdateSurveyByNodeIdInput {
   """
@@ -14848,6 +14892,11 @@ type UpdateTableOfContentsItemPayload {
     """The method to use when ordering `TableOfContentsItem`."""
     orderBy: [TableOfContentsItemsOrderBy!] = [PRIMARY_KEY_ASC]
   ): TableOfContentsItemsEdge
+}
+
+input UpdateTocItemParentInput {
+  id: Int!
+  type: SketchChildType!
 }
 
 """All input for the `updateTopicByNodeId` mutation."""

--- a/packages/api/generated-schema.gql
+++ b/packages/api/generated-schema.gql
@@ -4060,6 +4060,7 @@ type DeleteSketchPayload {
 }
 
 type DeleteSketchTocItemsResults {
+  deletedItems: [String!]!
   updatedCollections: [Sketch]!
 }
 
@@ -7362,7 +7363,13 @@ type Mutation {
     input: DeleteSketchFolderByNodeIdInput!
   ): DeleteSketchFolderPayload
 
-  """TODO: implement mutation and result resolvers"""
+  """
+  Deletes one or more Sketch or SketchFolders
+  
+  Returns an updatedCollections property which should be used to update the
+  updatedAt property on related collections so that correct cache keys are
+  used when requesting reports.
+  """
   deleteSketchTocItems(items: [UpdateTocItemParentInput]!): DeleteSketchTocItemsResults
 
   """Deletes a single `Survey` using a unique key."""
@@ -8264,6 +8271,11 @@ type Mutation {
   function again on userGeom. This ensures the value conforms to the
   project's rules, and also benefits the user in that they need not submit
   a huge geometry to the server.
+  
+  When updating a sketch, be sure to use the Sketch.parentCollection
+  association to update the client graphql cache with an up to date
+  updatedAt timestamp. This will ensure a correct cache key is used when
+  requesting collection reports.
   """
   updateSketch(
     id: Int!
@@ -8328,7 +8340,15 @@ type Mutation {
     input: UpdateSketchParentInput!
   ): UpdateSketchParentPayload
 
-  """TODO: implement mutation and result resolvers"""
+  """
+  Create to respond to drag & drop actions in the sketch table of contents.
+  Can assign a folder_id or collection_id to one or multiple Sketches or
+  SketchFolders.
+  
+  Returns an updatedCollections property which should be used to update the
+  updatedAt property on related collections so that correct cache keys are
+  used when requesting reports.
+  """
   updateSketchTocItemParent(collectionId: Int, folderId: Int, tocItems: [UpdateTocItemParentInput]!): UpdateSketchTocItemParentResults
 
   """Updates a single `Survey` using a unique key and a patch."""
@@ -10063,6 +10083,7 @@ type Query implements Node {
   We return "dev" if build cannot be determined from deployment environment.
   """
   build: String!
+  camelCase(snakeCase: String): String
   collectTextFromProsemirrorBody(body: JSON): String
   collectTextFromProsemirrorBodyForLabel(body: JSON): String
   communityGuideline(projectId: Int!): CommunityGuideline
@@ -10313,6 +10334,7 @@ type Query implements Node {
     """
     nodeId: ID!
   ): InviteEmail
+  lcfirst(word: String): String
 
   """
   Access the current session's User. The user is determined by the access token embedded in the `Authorization` header.
@@ -10760,6 +10782,7 @@ type Query implements Node {
     offset: Int
   ): [SketchClass!]
   tilebbox(srid: Int, x: Int, y: Int, z: Int): GeometryInterface
+  toGraphqlId(id: Int, type: String): String
   topic(id: Int!): Topic
 
   """Reads a single `Topic` using its globally unique `ID`."""

--- a/packages/api/generated-schema.gql
+++ b/packages/api/generated-schema.gql
@@ -875,6 +875,11 @@ type CopySketchTocItemResults {
   folders: [SketchFolder!]
   parentId: Int!
   sketches: [Sketch!]
+
+  """
+  Returns the parent collection (if exists) so that the client can select an updated updatedAt
+  """
+  updatedCollection: Sketch
 }
 
 """All input for the create `Basemap` mutation."""
@@ -4052,6 +4057,10 @@ type DeleteSketchPayload {
 
   """Reads a single `User` that is related to this `Sketch`."""
   user: User
+}
+
+type DeleteSketchTocItemsResults {
+  updatedCollections: [Sketch]!
 }
 
 """All input for the `deleteSurveyByNodeId` mutation."""
@@ -7353,6 +7362,9 @@ type Mutation {
     input: DeleteSketchFolderByNodeIdInput!
   ): DeleteSketchFolderPayload
 
+  """TODO: implement mutation and result resolvers"""
+  deleteSketchTocItems(items: [UpdateTocItemParentInput]!): DeleteSketchTocItemsResults
+
   """Deletes a single `Survey` using a unique key."""
   deleteSurvey(
     """
@@ -8315,6 +8327,9 @@ type Mutation {
     """
     input: UpdateSketchParentInput!
   ): UpdateSketchParentPayload
+
+  """TODO: implement mutation and result resolvers"""
+  updateSketchTocItemParent(collectionId: Int, folderId: Int, tocItems: [UpdateTocItemParentInput]!): UpdateSketchTocItemParentResults
 
   """Updates a single `Survey` using a unique key and a patch."""
   updateSurvey(
@@ -14511,6 +14526,12 @@ type UpdateSketchParentPayload {
   user: User
 }
 
+type UpdateSketchTocItemParentResults {
+  folders: [SketchFolder]!
+  sketches: [Sketch]!
+  updatedCollections: [Sketch]!
+}
+
 """All input for the `updateSurveyByNodeId` mutation."""
 input UpdateSurveyByNodeIdInput {
   """
@@ -14848,6 +14869,11 @@ type UpdateTableOfContentsItemPayload {
     """The method to use when ordering `TableOfContentsItem`."""
     orderBy: [TableOfContentsItemsOrderBy!] = [PRIMARY_KEY_ASC]
   ): TableOfContentsItemsEdge
+}
+
+input UpdateTocItemParentInput {
+  id: Int!
+  type: SketchChildType!
 }
 
 """All input for the `updateTopicByNodeId` mutation."""

--- a/packages/api/migrations/committed/000222.sql
+++ b/packages/api/migrations/committed/000222.sql
@@ -1,0 +1,86 @@
+--! Previous: sha1:3e66094de2ed6349dcd3c24d4b3cc0b3d3091a69
+--! Hash: sha1:ded79908099093a62a388b51993e90170cedfcb9
+
+-- Enter migration here
+
+
+
+drop function if exists get_all_sketch_toc_children;
+drop type if exists sketch_toc_child;
+
+create or replace function lcfirst(word text)
+returns text
+language plpgsql
+immutable
+as $$
+begin
+  return lower(left(word, 1)) || right(word, -1);
+end;
+$$;
+
+create or replace function camel_case(snake_case text)
+returns text
+language plpgsql
+immutable
+as $$
+begin
+  return
+    replace(
+      initcap(
+        replace(snake_case, '_', ' ')
+      ),
+      ' ', ''
+    );
+end;
+$$;
+
+grant execute on function camel_case to anon;
+grant execute on function lcfirst to anon;
+
+create or replace function to_graphql_id(type text, id int)
+  returns text
+  language plpgsql
+  immutable
+  as $$
+    begin
+    return camel_case(type || ':' || id::text);
+    end;
+  $$;
+
+grant execute on function to_graphql_id to anon;
+
+
+CREATE OR REPLACE FUNCTION public.get_all_sketch_toc_children(parent_id integer, parent_type public.sketch_child_type) RETURNS 
+    text[]
+    LANGUAGE plpgsql
+    AS $$
+  declare
+    ids text[] = '{}';
+    child_ids text[];
+    child record;
+  begin
+    if parent_type = 'sketch' then
+      FOR child IN SELECT * FROM get_children_of_collection(parent_id)
+      LOOP
+        ids := ids || to_graphql_id(child.type::text, child.id::int);
+        if child.is_leaf = false then
+          select get_all_sketch_toc_children(child.id, child.type) into child_ids;
+          ids := ids || child_ids;
+        end if;
+      END LOOP;
+    else
+      FOR child IN SELECT * FROM get_children_of_folder(parent_id)
+      LOOP
+        ids := ids || to_graphql_id(child.type::text, child.id::int);
+        if child.is_leaf = false then
+          select get_all_sketch_toc_children(child.id, child.type) into child_ids;
+          ids := ids || child_ids;
+        end if;
+      END LOOP;
+    end if;
+    return ids;
+  end;
+  $$;
+
+grant execute on function get_all_sketch_toc_children to seasketch_user;
+comment on function get_all_sketch_toc_children is '@omit';

--- a/packages/client/src/generated/graphql.ts
+++ b/packages/client/src/generated/graphql.ts
@@ -3447,6 +3447,7 @@ export type DeleteSketchPayload = {
 
 export type DeleteSketchTocItemsResults = {
   __typename?: 'DeleteSketchTocItemsResults';
+  deletedItems: Array<Scalars['String']>;
   updatedCollections: Array<Maybe<Sketch>>;
 };
 
@@ -5902,7 +5903,13 @@ export type Mutation = {
   deleteSketchFolder?: Maybe<DeleteSketchFolderPayload>;
   /** Deletes a single `SketchFolder` using its globally unique id. */
   deleteSketchFolderByNodeId?: Maybe<DeleteSketchFolderPayload>;
-  /** TODO: implement mutation and result resolvers */
+  /**
+   * Deletes one or more Sketch or SketchFolders
+   *
+   * Returns an updatedCollections property which should be used to update the
+   * updatedAt property on related collections so that correct cache keys are
+   * used when requesting reports.
+   */
   deleteSketchTocItems?: Maybe<DeleteSketchTocItemsResults>;
   /** Deletes a single `Survey` using a unique key. */
   deleteSurvey?: Maybe<DeleteSurveyPayload>;
@@ -6157,6 +6164,11 @@ export type Mutation = {
    * function again on userGeom. This ensures the value conforms to the
    * project's rules, and also benefits the user in that they need not submit
    * a huge geometry to the server.
+   *
+   * When updating a sketch, be sure to use the Sketch.parentCollection
+   * association to update the client graphql cache with an up to date
+   * updatedAt timestamp. This will ensure a correct cache key is used when
+   * requesting collection reports.
    */
   updateSketch?: Maybe<Sketch>;
   /** Updates a single `SketchClass` using a unique key and a patch. */
@@ -6170,7 +6182,15 @@ export type Mutation = {
   /** Updates a single `SketchFolder` using its globally unique id and a patch. */
   updateSketchFolderByNodeId?: Maybe<UpdateSketchFolderPayload>;
   updateSketchParent?: Maybe<UpdateSketchParentPayload>;
-  /** TODO: implement mutation and result resolvers */
+  /**
+   * Create to respond to drag & drop actions in the sketch table of contents.
+   * Can assign a folder_id or collection_id to one or multiple Sketches or
+   * SketchFolders.
+   *
+   * Returns an updatedCollections property which should be used to update the
+   * updatedAt property on related collections so that correct cache keys are
+   * used when requesting reports.
+   */
   updateSketchTocItemParent?: Maybe<UpdateSketchTocItemParentResults>;
   /** Updates a single `Survey` using a unique key and a patch. */
   updateSurvey?: Maybe<UpdateSurveyPayload>;
@@ -8930,6 +8950,7 @@ export type Query = Node & {
    * We return "dev" if build cannot be determined from deployment environment.
    */
   build: Scalars['String'];
+  camelCase?: Maybe<Scalars['String']>;
   collectTextFromProsemirrorBody?: Maybe<Scalars['String']>;
   collectTextFromProsemirrorBodyForLabel?: Maybe<Scalars['String']>;
   communityGuideline?: Maybe<CommunityGuideline>;
@@ -9000,6 +9021,7 @@ export type Query = Node & {
   inviteEmail?: Maybe<InviteEmail>;
   /** Reads a single `InviteEmail` using its globally unique `ID`. */
   inviteEmailByNodeId?: Maybe<InviteEmail>;
+  lcfirst?: Maybe<Scalars['String']>;
   /** Access the current session's User. The user is determined by the access token embedded in the `Authorization` header. */
   me?: Maybe<User>;
   /** Fetches an object given its globally unique `ID`. */
@@ -9098,6 +9120,7 @@ export type Query = Node & {
   /** List of template sketch classes such as "Marine Protected Area", "MPA Network", etc. */
   templateSketchClasses?: Maybe<Array<SketchClass>>;
   tilebbox?: Maybe<GeometryInterface>;
+  toGraphqlId?: Maybe<Scalars['String']>;
   topic?: Maybe<Topic>;
   /** Reads a single `Topic` using its globally unique `ID`. */
   topicByNodeId?: Maybe<Topic>;
@@ -9177,6 +9200,12 @@ export type QueryBasemapsConnectionArgs = {
   last?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<Array<BasemapsOrderBy>>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryCamelCaseArgs = {
+  snakeCase?: Maybe<Scalars['String']>;
 };
 
 
@@ -9474,6 +9503,12 @@ export type QueryInviteEmailArgs = {
 /** The root query type which gives access points into the data universe. */
 export type QueryInviteEmailByNodeIdArgs = {
   nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryLcfirstArgs = {
+  word?: Maybe<Scalars['String']>;
 };
 
 
@@ -9899,6 +9934,13 @@ export type QueryTilebboxArgs = {
   x?: Maybe<Scalars['Int']>;
   y?: Maybe<Scalars['Int']>;
   z?: Maybe<Scalars['Int']>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryToGraphqlIdArgs = {
+  id?: Maybe<Scalars['Int']>;
+  type?: Maybe<Scalars['String']>;
 };
 
 
@@ -16306,35 +16348,20 @@ export type UpdateSketchMutation = (
   )> }
 );
 
-export type DeleteSketchMutationVariables = Exact<{
-  id: Scalars['Int'];
+export type DeleteSketchTocItemsMutationVariables = Exact<{
+  items: Array<Maybe<UpdateTocItemParentInput>> | Maybe<UpdateTocItemParentInput>;
 }>;
 
 
-export type DeleteSketchMutation = (
+export type DeleteSketchTocItemsMutation = (
   { __typename?: 'Mutation' }
-  & { deleteSketch?: Maybe<(
-    { __typename?: 'DeleteSketchPayload' }
-    & { sketch?: Maybe<(
+  & { deleteSketchTocItems?: Maybe<(
+    { __typename?: 'DeleteSketchTocItemsResults' }
+    & Pick<DeleteSketchTocItemsResults, 'deletedItems'>
+    & { updatedCollections: Array<Maybe<(
       { __typename?: 'Sketch' }
-      & Pick<Sketch, 'id'>
-    )> }
-  )> }
-);
-
-export type DeleteSketchFolderMutationVariables = Exact<{
-  id: Scalars['Int'];
-}>;
-
-
-export type DeleteSketchFolderMutation = (
-  { __typename?: 'Mutation' }
-  & { deleteSketchFolder?: Maybe<(
-    { __typename?: 'DeleteSketchFolderPayload' }
-    & { sketchFolder?: Maybe<(
-      { __typename?: 'SketchFolder' }
-      & Pick<SketchFolder, 'id'>
-    )> }
+      & Pick<Sketch, 'id' | 'updatedAt'>
+    )>> }
   )> }
 );
 
@@ -16412,14 +16439,10 @@ export type UpdateTocItemsParentMutation = (
     { __typename?: 'UpdateSketchTocItemParentResults' }
     & { folders: Array<Maybe<(
       { __typename?: 'SketchFolder' }
-      & Pick<SketchFolder, 'id'>
+      & Pick<SketchFolder, 'id' | 'folderId' | 'collectionId'>
     )>>, sketches: Array<Maybe<(
       { __typename?: 'Sketch' }
-      & Pick<Sketch, 'id' | 'updatedAt'>
-      & { parentCollection?: Maybe<(
-        { __typename?: 'Sketch' }
-        & Pick<Sketch, 'id' | 'updatedAt'>
-      )> }
+      & Pick<Sketch, 'id' | 'updatedAt' | 'folderId' | 'collectionId'>
     )>>, updatedCollections: Array<Maybe<(
       { __typename?: 'Sketch' }
       & Pick<Sketch, 'id' | 'updatedAt'>
@@ -24426,76 +24449,43 @@ export function useUpdateSketchMutation(baseOptions?: Apollo.MutationHookOptions
 export type UpdateSketchMutationHookResult = ReturnType<typeof useUpdateSketchMutation>;
 export type UpdateSketchMutationResult = Apollo.MutationResult<UpdateSketchMutation>;
 export type UpdateSketchMutationOptions = Apollo.BaseMutationOptions<UpdateSketchMutation, UpdateSketchMutationVariables>;
-export const DeleteSketchDocument = gql`
-    mutation DeleteSketch($id: Int!) {
-  deleteSketch(input: {id: $id}) {
-    sketch {
+export const DeleteSketchTocItemsDocument = gql`
+    mutation DeleteSketchTocItems($items: [UpdateTocItemParentInput]!) {
+  deleteSketchTocItems(items: $items) {
+    deletedItems
+    updatedCollections {
       id
+      updatedAt
     }
   }
 }
     `;
-export type DeleteSketchMutationFn = Apollo.MutationFunction<DeleteSketchMutation, DeleteSketchMutationVariables>;
+export type DeleteSketchTocItemsMutationFn = Apollo.MutationFunction<DeleteSketchTocItemsMutation, DeleteSketchTocItemsMutationVariables>;
 
 /**
- * __useDeleteSketchMutation__
+ * __useDeleteSketchTocItemsMutation__
  *
- * To run a mutation, you first call `useDeleteSketchMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useDeleteSketchMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useDeleteSketchTocItemsMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDeleteSketchTocItemsMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [deleteSketchMutation, { data, loading, error }] = useDeleteSketchMutation({
+ * const [deleteSketchTocItemsMutation, { data, loading, error }] = useDeleteSketchTocItemsMutation({
  *   variables: {
- *      id: // value for 'id'
+ *      items: // value for 'items'
  *   },
  * });
  */
-export function useDeleteSketchMutation(baseOptions?: Apollo.MutationHookOptions<DeleteSketchMutation, DeleteSketchMutationVariables>) {
+export function useDeleteSketchTocItemsMutation(baseOptions?: Apollo.MutationHookOptions<DeleteSketchTocItemsMutation, DeleteSketchTocItemsMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<DeleteSketchMutation, DeleteSketchMutationVariables>(DeleteSketchDocument, options);
+        return Apollo.useMutation<DeleteSketchTocItemsMutation, DeleteSketchTocItemsMutationVariables>(DeleteSketchTocItemsDocument, options);
       }
-export type DeleteSketchMutationHookResult = ReturnType<typeof useDeleteSketchMutation>;
-export type DeleteSketchMutationResult = Apollo.MutationResult<DeleteSketchMutation>;
-export type DeleteSketchMutationOptions = Apollo.BaseMutationOptions<DeleteSketchMutation, DeleteSketchMutationVariables>;
-export const DeleteSketchFolderDocument = gql`
-    mutation DeleteSketchFolder($id: Int!) {
-  deleteSketchFolder(input: {id: $id}) {
-    sketchFolder {
-      id
-    }
-  }
-}
-    `;
-export type DeleteSketchFolderMutationFn = Apollo.MutationFunction<DeleteSketchFolderMutation, DeleteSketchFolderMutationVariables>;
-
-/**
- * __useDeleteSketchFolderMutation__
- *
- * To run a mutation, you first call `useDeleteSketchFolderMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useDeleteSketchFolderMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [deleteSketchFolderMutation, { data, loading, error }] = useDeleteSketchFolderMutation({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useDeleteSketchFolderMutation(baseOptions?: Apollo.MutationHookOptions<DeleteSketchFolderMutation, DeleteSketchFolderMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<DeleteSketchFolderMutation, DeleteSketchFolderMutationVariables>(DeleteSketchFolderDocument, options);
-      }
-export type DeleteSketchFolderMutationHookResult = ReturnType<typeof useDeleteSketchFolderMutation>;
-export type DeleteSketchFolderMutationResult = Apollo.MutationResult<DeleteSketchFolderMutation>;
-export type DeleteSketchFolderMutationOptions = Apollo.BaseMutationOptions<DeleteSketchFolderMutation, DeleteSketchFolderMutationVariables>;
+export type DeleteSketchTocItemsMutationHookResult = ReturnType<typeof useDeleteSketchTocItemsMutation>;
+export type DeleteSketchTocItemsMutationResult = Apollo.MutationResult<DeleteSketchTocItemsMutation>;
+export type DeleteSketchTocItemsMutationOptions = Apollo.BaseMutationOptions<DeleteSketchTocItemsMutation, DeleteSketchTocItemsMutationVariables>;
 export const RenameFolderDocument = gql`
     mutation RenameFolder($id: Int!, $name: String!) {
   updateSketchFolder(input: {id: $id, patch: {name: $name}}) {
@@ -24577,14 +24567,14 @@ export const UpdateTocItemsParentDocument = gql`
   ) {
     folders {
       id
+      folderId
+      collectionId
     }
     sketches {
       id
       updatedAt
-      parentCollection {
-        id
-        updatedAt
-      }
+      folderId
+      collectionId
     }
     updatedCollections {
       id
@@ -27779,8 +27769,7 @@ export const namedOperations = {
     CreateSketchFolder: 'CreateSketchFolder',
     CreateSketch: 'CreateSketch',
     UpdateSketch: 'UpdateSketch',
-    DeleteSketch: 'DeleteSketch',
-    DeleteSketchFolder: 'DeleteSketchFolder',
+    DeleteSketchTocItems: 'DeleteSketchTocItems',
     RenameFolder: 'RenameFolder',
     UpdateTocItemsParent: 'UpdateTocItemsParent',
     CopyTocItem: 'CopyTocItem',

--- a/packages/client/src/generated/graphql.ts
+++ b/packages/client/src/generated/graphql.ts
@@ -771,6 +771,8 @@ export type CopySketchTocItemResults = {
   folders?: Maybe<Array<SketchFolder>>;
   parentId: Scalars['Int'];
   sketches?: Maybe<Array<Sketch>>;
+  /** Returns the parent collection (if exists) so that the client can select an updated updatedAt */
+  updatedCollection?: Maybe<Sketch>;
 };
 
 /** All input for the create `Basemap` mutation. */
@@ -3443,6 +3445,11 @@ export type DeleteSketchPayload = {
   user?: Maybe<User>;
 };
 
+export type DeleteSketchTocItemsResults = {
+  __typename?: 'DeleteSketchTocItemsResults';
+  updatedCollections: Array<Maybe<Sketch>>;
+};
+
 /** All input for the `deleteSurveyByNodeId` mutation. */
 export type DeleteSurveyByNodeIdInput = {
   /**
@@ -5895,6 +5902,8 @@ export type Mutation = {
   deleteSketchFolder?: Maybe<DeleteSketchFolderPayload>;
   /** Deletes a single `SketchFolder` using its globally unique id. */
   deleteSketchFolderByNodeId?: Maybe<DeleteSketchFolderPayload>;
+  /** TODO: implement mutation and result resolvers */
+  deleteSketchTocItems?: Maybe<DeleteSketchTocItemsResults>;
   /** Deletes a single `Survey` using a unique key. */
   deleteSurvey?: Maybe<DeleteSurveyPayload>;
   /** Deletes a single `Survey` using its globally unique id. */
@@ -6161,6 +6170,8 @@ export type Mutation = {
   /** Updates a single `SketchFolder` using its globally unique id and a patch. */
   updateSketchFolderByNodeId?: Maybe<UpdateSketchFolderPayload>;
   updateSketchParent?: Maybe<UpdateSketchParentPayload>;
+  /** TODO: implement mutation and result resolvers */
+  updateSketchTocItemParent?: Maybe<UpdateSketchTocItemParentResults>;
   /** Updates a single `Survey` using a unique key and a patch. */
   updateSurvey?: Maybe<UpdateSurveyPayload>;
   /** Updates a single `Survey` using its globally unique id and a patch. */
@@ -6757,6 +6768,12 @@ export type MutationDeleteSketchFolderArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteSketchFolderByNodeIdArgs = {
   input: DeleteSketchFolderByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteSketchTocItemsArgs = {
+  items: Array<Maybe<UpdateTocItemParentInput>>;
 };
 
 
@@ -7422,6 +7439,14 @@ export type MutationUpdateSketchFolderByNodeIdArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateSketchParentArgs = {
   input: UpdateSketchParentInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateSketchTocItemParentArgs = {
+  collectionId?: Maybe<Scalars['Int']>;
+  folderId?: Maybe<Scalars['Int']>;
+  tocItems: Array<Maybe<UpdateTocItemParentInput>>;
 };
 
 
@@ -12910,6 +12935,13 @@ export type UpdateSketchParentPayload = {
   user?: Maybe<User>;
 };
 
+export type UpdateSketchTocItemParentResults = {
+  __typename?: 'UpdateSketchTocItemParentResults';
+  folders: Array<Maybe<SketchFolder>>;
+  sketches: Array<Maybe<Sketch>>;
+  updatedCollections: Array<Maybe<Sketch>>;
+};
+
 /** All input for the `updateSurveyByNodeId` mutation. */
 export type UpdateSurveyByNodeIdInput = {
   /**
@@ -13182,6 +13214,11 @@ export type UpdateTableOfContentsItemPayload = {
 /** The output of our update `TableOfContentsItem` mutation. */
 export type UpdateTableOfContentsItemPayloadTableOfContentsItemEdgeArgs = {
   orderBy?: Maybe<Array<TableOfContentsItemsOrderBy>>;
+};
+
+export type UpdateTocItemParentInput = {
+  id: Scalars['Int'];
+  type: SketchChildType;
 };
 
 /** All input for the `updateTopicByNodeId` mutation. */
@@ -16362,39 +16399,31 @@ export type GetSketchForEditingQuery = (
   )> }
 );
 
-export type UpdateSketchFolderParentMutationVariables = Exact<{
-  id: Scalars['Int'];
+export type UpdateTocItemsParentMutationVariables = Exact<{
   folderId?: Maybe<Scalars['Int']>;
   collectionId?: Maybe<Scalars['Int']>;
+  tocItems: Array<Maybe<UpdateTocItemParentInput>> | Maybe<UpdateTocItemParentInput>;
 }>;
 
 
-export type UpdateSketchFolderParentMutation = (
+export type UpdateTocItemsParentMutation = (
   { __typename?: 'Mutation' }
-  & { updateSketchFolder?: Maybe<(
-    { __typename?: 'UpdateSketchFolderPayload' }
-    & { sketchFolder?: Maybe<(
+  & { updateSketchTocItemParent?: Maybe<(
+    { __typename?: 'UpdateSketchTocItemParentResults' }
+    & { folders: Array<Maybe<(
       { __typename?: 'SketchFolder' }
-      & Pick<SketchFolder, 'id' | 'folderId' | 'collectionId'>
-    )> }
-  )> }
-);
-
-export type UpdateSketchParentMutationVariables = Exact<{
-  id: Scalars['Int'];
-  folderId?: Maybe<Scalars['Int']>;
-  collectionId?: Maybe<Scalars['Int']>;
-}>;
-
-
-export type UpdateSketchParentMutation = (
-  { __typename?: 'Mutation' }
-  & { updateSketchParent?: Maybe<(
-    { __typename?: 'UpdateSketchParentPayload' }
-    & { sketch?: Maybe<(
+      & Pick<SketchFolder, 'id'>
+    )>>, sketches: Array<Maybe<(
       { __typename?: 'Sketch' }
-      & Pick<Sketch, 'id' | 'folderId' | 'collectionId'>
-    )> }
+      & Pick<Sketch, 'id' | 'updatedAt'>
+      & { parentCollection?: Maybe<(
+        { __typename?: 'Sketch' }
+        & Pick<Sketch, 'id' | 'updatedAt'>
+      )> }
+    )>>, updatedCollections: Array<Maybe<(
+      { __typename?: 'Sketch' }
+      & Pick<Sketch, 'id' | 'updatedAt'>
+    )>> }
   )> }
 );
 
@@ -16423,38 +16452,6 @@ export type SketchReportingDetailsQuery = (
   )> }
 );
 
-export type CopySketchMutationVariables = Exact<{
-  id: Scalars['Int'];
-}>;
-
-
-export type CopySketchMutation = (
-  { __typename?: 'Mutation' }
-  & { copySketch?: Maybe<(
-    { __typename?: 'CopySketchPayload' }
-    & { sketch?: Maybe<(
-      { __typename?: 'Sketch' }
-      & SketchTocDetailsFragment
-    )> }
-  )> }
-);
-
-export type CopySketchFolderMutationVariables = Exact<{
-  id: Scalars['Int'];
-}>;
-
-
-export type CopySketchFolderMutation = (
-  { __typename?: 'Mutation' }
-  & { copySketchFolder?: Maybe<(
-    { __typename?: 'CopySketchFolderPayload' }
-    & { sketchFolder?: Maybe<(
-      { __typename?: 'SketchFolder' }
-      & SketchFolderDetailsFragment
-    )> }
-  )> }
-);
-
 export type CopyTocItemMutationVariables = Exact<{
   id: Scalars['Int'];
   type: SketchChildType;
@@ -16472,7 +16469,10 @@ export type CopyTocItemMutation = (
     )>>, sketches?: Maybe<Array<(
       { __typename?: 'Sketch' }
       & SketchTocDetailsFragment
-    )>> }
+    )>>, updatedCollection?: Maybe<(
+      { __typename?: 'Sketch' }
+      & Pick<Sketch, 'id' | 'updatedAt'>
+    )> }
   )> }
 );
 
@@ -24568,88 +24568,59 @@ export function useGetSketchForEditingLazyQuery(baseOptions?: Apollo.LazyQueryHo
 export type GetSketchForEditingQueryHookResult = ReturnType<typeof useGetSketchForEditingQuery>;
 export type GetSketchForEditingLazyQueryHookResult = ReturnType<typeof useGetSketchForEditingLazyQuery>;
 export type GetSketchForEditingQueryResult = Apollo.QueryResult<GetSketchForEditingQuery, GetSketchForEditingQueryVariables>;
-export const UpdateSketchFolderParentDocument = gql`
-    mutation UpdateSketchFolderParent($id: Int!, $folderId: Int, $collectionId: Int) {
-  updateSketchFolder(
-    input: {id: $id, patch: {folderId: $folderId, collectionId: $collectionId}}
+export const UpdateTocItemsParentDocument = gql`
+    mutation UpdateTocItemsParent($folderId: Int, $collectionId: Int, $tocItems: [UpdateTocItemParentInput]!) {
+  updateSketchTocItemParent(
+    folderId: $folderId
+    collectionId: $collectionId
+    tocItems: $tocItems
   ) {
-    sketchFolder {
+    folders {
       id
-      folderId
-      collectionId
+    }
+    sketches {
+      id
+      updatedAt
+      parentCollection {
+        id
+        updatedAt
+      }
+    }
+    updatedCollections {
+      id
+      updatedAt
     }
   }
 }
     `;
-export type UpdateSketchFolderParentMutationFn = Apollo.MutationFunction<UpdateSketchFolderParentMutation, UpdateSketchFolderParentMutationVariables>;
+export type UpdateTocItemsParentMutationFn = Apollo.MutationFunction<UpdateTocItemsParentMutation, UpdateTocItemsParentMutationVariables>;
 
 /**
- * __useUpdateSketchFolderParentMutation__
+ * __useUpdateTocItemsParentMutation__
  *
- * To run a mutation, you first call `useUpdateSketchFolderParentMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateSketchFolderParentMutation` returns a tuple that includes:
+ * To run a mutation, you first call `useUpdateTocItemsParentMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateTocItemsParentMutation` returns a tuple that includes:
  * - A mutate function that you can call at any time to execute the mutation
  * - An object with fields that represent the current status of the mutation's execution
  *
  * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
  *
  * @example
- * const [updateSketchFolderParentMutation, { data, loading, error }] = useUpdateSketchFolderParentMutation({
+ * const [updateTocItemsParentMutation, { data, loading, error }] = useUpdateTocItemsParentMutation({
  *   variables: {
- *      id: // value for 'id'
  *      folderId: // value for 'folderId'
  *      collectionId: // value for 'collectionId'
+ *      tocItems: // value for 'tocItems'
  *   },
  * });
  */
-export function useUpdateSketchFolderParentMutation(baseOptions?: Apollo.MutationHookOptions<UpdateSketchFolderParentMutation, UpdateSketchFolderParentMutationVariables>) {
+export function useUpdateTocItemsParentMutation(baseOptions?: Apollo.MutationHookOptions<UpdateTocItemsParentMutation, UpdateTocItemsParentMutationVariables>) {
         const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateSketchFolderParentMutation, UpdateSketchFolderParentMutationVariables>(UpdateSketchFolderParentDocument, options);
+        return Apollo.useMutation<UpdateTocItemsParentMutation, UpdateTocItemsParentMutationVariables>(UpdateTocItemsParentDocument, options);
       }
-export type UpdateSketchFolderParentMutationHookResult = ReturnType<typeof useUpdateSketchFolderParentMutation>;
-export type UpdateSketchFolderParentMutationResult = Apollo.MutationResult<UpdateSketchFolderParentMutation>;
-export type UpdateSketchFolderParentMutationOptions = Apollo.BaseMutationOptions<UpdateSketchFolderParentMutation, UpdateSketchFolderParentMutationVariables>;
-export const UpdateSketchParentDocument = gql`
-    mutation UpdateSketchParent($id: Int!, $folderId: Int, $collectionId: Int) {
-  updateSketchParent(
-    input: {id: $id, folderId: $folderId, collectionId: $collectionId}
-  ) {
-    sketch {
-      id
-      folderId
-      collectionId
-    }
-  }
-}
-    `;
-export type UpdateSketchParentMutationFn = Apollo.MutationFunction<UpdateSketchParentMutation, UpdateSketchParentMutationVariables>;
-
-/**
- * __useUpdateSketchParentMutation__
- *
- * To run a mutation, you first call `useUpdateSketchParentMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useUpdateSketchParentMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [updateSketchParentMutation, { data, loading, error }] = useUpdateSketchParentMutation({
- *   variables: {
- *      id: // value for 'id'
- *      folderId: // value for 'folderId'
- *      collectionId: // value for 'collectionId'
- *   },
- * });
- */
-export function useUpdateSketchParentMutation(baseOptions?: Apollo.MutationHookOptions<UpdateSketchParentMutation, UpdateSketchParentMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<UpdateSketchParentMutation, UpdateSketchParentMutationVariables>(UpdateSketchParentDocument, options);
-      }
-export type UpdateSketchParentMutationHookResult = ReturnType<typeof useUpdateSketchParentMutation>;
-export type UpdateSketchParentMutationResult = Apollo.MutationResult<UpdateSketchParentMutation>;
-export type UpdateSketchParentMutationOptions = Apollo.BaseMutationOptions<UpdateSketchParentMutation, UpdateSketchParentMutationVariables>;
+export type UpdateTocItemsParentMutationHookResult = ReturnType<typeof useUpdateTocItemsParentMutation>;
+export type UpdateTocItemsParentMutationResult = Apollo.MutationResult<UpdateTocItemsParentMutation>;
+export type UpdateTocItemsParentMutationOptions = Apollo.BaseMutationOptions<UpdateTocItemsParentMutation, UpdateTocItemsParentMutationVariables>;
 export const SketchReportingDetailsDocument = gql`
     query SketchReportingDetails($id: Int!, $sketchClassId: Int!) {
   sketch(id: $id) {
@@ -24711,76 +24682,6 @@ export function useSketchReportingDetailsLazyQuery(baseOptions?: Apollo.LazyQuer
 export type SketchReportingDetailsQueryHookResult = ReturnType<typeof useSketchReportingDetailsQuery>;
 export type SketchReportingDetailsLazyQueryHookResult = ReturnType<typeof useSketchReportingDetailsLazyQuery>;
 export type SketchReportingDetailsQueryResult = Apollo.QueryResult<SketchReportingDetailsQuery, SketchReportingDetailsQueryVariables>;
-export const CopySketchDocument = gql`
-    mutation CopySketch($id: Int!) {
-  copySketch(input: {sketchId: $id}) {
-    sketch {
-      ...SketchTocDetails
-    }
-  }
-}
-    ${SketchTocDetailsFragmentDoc}`;
-export type CopySketchMutationFn = Apollo.MutationFunction<CopySketchMutation, CopySketchMutationVariables>;
-
-/**
- * __useCopySketchMutation__
- *
- * To run a mutation, you first call `useCopySketchMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCopySketchMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [copySketchMutation, { data, loading, error }] = useCopySketchMutation({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useCopySketchMutation(baseOptions?: Apollo.MutationHookOptions<CopySketchMutation, CopySketchMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CopySketchMutation, CopySketchMutationVariables>(CopySketchDocument, options);
-      }
-export type CopySketchMutationHookResult = ReturnType<typeof useCopySketchMutation>;
-export type CopySketchMutationResult = Apollo.MutationResult<CopySketchMutation>;
-export type CopySketchMutationOptions = Apollo.BaseMutationOptions<CopySketchMutation, CopySketchMutationVariables>;
-export const CopySketchFolderDocument = gql`
-    mutation CopySketchFolder($id: Int!) {
-  copySketchFolder(input: {folderId: $id}) {
-    sketchFolder {
-      ...SketchFolderDetails
-    }
-  }
-}
-    ${SketchFolderDetailsFragmentDoc}`;
-export type CopySketchFolderMutationFn = Apollo.MutationFunction<CopySketchFolderMutation, CopySketchFolderMutationVariables>;
-
-/**
- * __useCopySketchFolderMutation__
- *
- * To run a mutation, you first call `useCopySketchFolderMutation` within a React component and pass it any options that fit your needs.
- * When your component renders, `useCopySketchFolderMutation` returns a tuple that includes:
- * - A mutate function that you can call at any time to execute the mutation
- * - An object with fields that represent the current status of the mutation's execution
- *
- * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
- *
- * @example
- * const [copySketchFolderMutation, { data, loading, error }] = useCopySketchFolderMutation({
- *   variables: {
- *      id: // value for 'id'
- *   },
- * });
- */
-export function useCopySketchFolderMutation(baseOptions?: Apollo.MutationHookOptions<CopySketchFolderMutation, CopySketchFolderMutationVariables>) {
-        const options = {...defaultOptions, ...baseOptions}
-        return Apollo.useMutation<CopySketchFolderMutation, CopySketchFolderMutationVariables>(CopySketchFolderDocument, options);
-      }
-export type CopySketchFolderMutationHookResult = ReturnType<typeof useCopySketchFolderMutation>;
-export type CopySketchFolderMutationResult = Apollo.MutationResult<CopySketchFolderMutation>;
-export type CopySketchFolderMutationOptions = Apollo.BaseMutationOptions<CopySketchFolderMutation, CopySketchFolderMutationVariables>;
 export const CopyTocItemDocument = gql`
     mutation CopyTocItem($id: Int!, $type: SketchChildType!) {
   copySketchTocItem(id: $id, type: $type) {
@@ -24791,6 +24692,10 @@ export const CopyTocItemDocument = gql`
       ...SketchTocDetails
     }
     parentId
+    updatedCollection {
+      id
+      updatedAt
+    }
   }
 }
     ${SketchFolderDetailsFragmentDoc}
@@ -27877,10 +27782,7 @@ export const namedOperations = {
     DeleteSketch: 'DeleteSketch',
     DeleteSketchFolder: 'DeleteSketchFolder',
     RenameFolder: 'RenameFolder',
-    UpdateSketchFolderParent: 'UpdateSketchFolderParent',
-    UpdateSketchParent: 'UpdateSketchParent',
-    CopySketch: 'CopySketch',
-    CopySketchFolder: 'CopySketchFolder',
+    UpdateTocItemsParent: 'UpdateTocItemsParent',
     CopyTocItem: 'CopyTocItem',
     CreateSurvey: 'CreateSurvey',
     UpdateSurveyBaseSettings: 'UpdateSurveyBaseSettings',

--- a/packages/client/src/generated/queries.ts
+++ b/packages/client/src/generated/queries.ts
@@ -3445,6 +3445,7 @@ export type DeleteSketchPayload = {
 
 export type DeleteSketchTocItemsResults = {
   __typename?: 'DeleteSketchTocItemsResults';
+  deletedItems: Array<Scalars['String']>;
   updatedCollections: Array<Maybe<Sketch>>;
 };
 
@@ -5900,7 +5901,13 @@ export type Mutation = {
   deleteSketchFolder?: Maybe<DeleteSketchFolderPayload>;
   /** Deletes a single `SketchFolder` using its globally unique id. */
   deleteSketchFolderByNodeId?: Maybe<DeleteSketchFolderPayload>;
-  /** TODO: implement mutation and result resolvers */
+  /**
+   * Deletes one or more Sketch or SketchFolders
+   *
+   * Returns an updatedCollections property which should be used to update the
+   * updatedAt property on related collections so that correct cache keys are
+   * used when requesting reports.
+   */
   deleteSketchTocItems?: Maybe<DeleteSketchTocItemsResults>;
   /** Deletes a single `Survey` using a unique key. */
   deleteSurvey?: Maybe<DeleteSurveyPayload>;
@@ -6155,6 +6162,11 @@ export type Mutation = {
    * function again on userGeom. This ensures the value conforms to the
    * project's rules, and also benefits the user in that they need not submit
    * a huge geometry to the server.
+   *
+   * When updating a sketch, be sure to use the Sketch.parentCollection
+   * association to update the client graphql cache with an up to date
+   * updatedAt timestamp. This will ensure a correct cache key is used when
+   * requesting collection reports.
    */
   updateSketch?: Maybe<Sketch>;
   /** Updates a single `SketchClass` using a unique key and a patch. */
@@ -6168,7 +6180,15 @@ export type Mutation = {
   /** Updates a single `SketchFolder` using its globally unique id and a patch. */
   updateSketchFolderByNodeId?: Maybe<UpdateSketchFolderPayload>;
   updateSketchParent?: Maybe<UpdateSketchParentPayload>;
-  /** TODO: implement mutation and result resolvers */
+  /**
+   * Create to respond to drag & drop actions in the sketch table of contents.
+   * Can assign a folder_id or collection_id to one or multiple Sketches or
+   * SketchFolders.
+   *
+   * Returns an updatedCollections property which should be used to update the
+   * updatedAt property on related collections so that correct cache keys are
+   * used when requesting reports.
+   */
   updateSketchTocItemParent?: Maybe<UpdateSketchTocItemParentResults>;
   /** Updates a single `Survey` using a unique key and a patch. */
   updateSurvey?: Maybe<UpdateSurveyPayload>;
@@ -8928,6 +8948,7 @@ export type Query = Node & {
    * We return "dev" if build cannot be determined from deployment environment.
    */
   build: Scalars['String'];
+  camelCase?: Maybe<Scalars['String']>;
   collectTextFromProsemirrorBody?: Maybe<Scalars['String']>;
   collectTextFromProsemirrorBodyForLabel?: Maybe<Scalars['String']>;
   communityGuideline?: Maybe<CommunityGuideline>;
@@ -8998,6 +9019,7 @@ export type Query = Node & {
   inviteEmail?: Maybe<InviteEmail>;
   /** Reads a single `InviteEmail` using its globally unique `ID`. */
   inviteEmailByNodeId?: Maybe<InviteEmail>;
+  lcfirst?: Maybe<Scalars['String']>;
   /** Access the current session's User. The user is determined by the access token embedded in the `Authorization` header. */
   me?: Maybe<User>;
   /** Fetches an object given its globally unique `ID`. */
@@ -9096,6 +9118,7 @@ export type Query = Node & {
   /** List of template sketch classes such as "Marine Protected Area", "MPA Network", etc. */
   templateSketchClasses?: Maybe<Array<SketchClass>>;
   tilebbox?: Maybe<GeometryInterface>;
+  toGraphqlId?: Maybe<Scalars['String']>;
   topic?: Maybe<Topic>;
   /** Reads a single `Topic` using its globally unique `ID`. */
   topicByNodeId?: Maybe<Topic>;
@@ -9175,6 +9198,12 @@ export type QueryBasemapsConnectionArgs = {
   last?: Maybe<Scalars['Int']>;
   offset?: Maybe<Scalars['Int']>;
   orderBy?: Maybe<Array<BasemapsOrderBy>>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryCamelCaseArgs = {
+  snakeCase?: Maybe<Scalars['String']>;
 };
 
 
@@ -9472,6 +9501,12 @@ export type QueryInviteEmailArgs = {
 /** The root query type which gives access points into the data universe. */
 export type QueryInviteEmailByNodeIdArgs = {
   nodeId: Scalars['ID'];
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryLcfirstArgs = {
+  word?: Maybe<Scalars['String']>;
 };
 
 
@@ -9897,6 +9932,13 @@ export type QueryTilebboxArgs = {
   x?: Maybe<Scalars['Int']>;
   y?: Maybe<Scalars['Int']>;
   z?: Maybe<Scalars['Int']>;
+};
+
+
+/** The root query type which gives access points into the data universe. */
+export type QueryToGraphqlIdArgs = {
+  id?: Maybe<Scalars['Int']>;
+  type?: Maybe<Scalars['String']>;
 };
 
 
@@ -16304,35 +16346,20 @@ export type UpdateSketchMutation = (
   )> }
 );
 
-export type DeleteSketchMutationVariables = Exact<{
-  id: Scalars['Int'];
+export type DeleteSketchTocItemsMutationVariables = Exact<{
+  items: Array<Maybe<UpdateTocItemParentInput>> | Maybe<UpdateTocItemParentInput>;
 }>;
 
 
-export type DeleteSketchMutation = (
+export type DeleteSketchTocItemsMutation = (
   { __typename?: 'Mutation' }
-  & { deleteSketch?: Maybe<(
-    { __typename?: 'DeleteSketchPayload' }
-    & { sketch?: Maybe<(
+  & { deleteSketchTocItems?: Maybe<(
+    { __typename?: 'DeleteSketchTocItemsResults' }
+    & Pick<DeleteSketchTocItemsResults, 'deletedItems'>
+    & { updatedCollections: Array<Maybe<(
       { __typename?: 'Sketch' }
-      & Pick<Sketch, 'id'>
-    )> }
-  )> }
-);
-
-export type DeleteSketchFolderMutationVariables = Exact<{
-  id: Scalars['Int'];
-}>;
-
-
-export type DeleteSketchFolderMutation = (
-  { __typename?: 'Mutation' }
-  & { deleteSketchFolder?: Maybe<(
-    { __typename?: 'DeleteSketchFolderPayload' }
-    & { sketchFolder?: Maybe<(
-      { __typename?: 'SketchFolder' }
-      & Pick<SketchFolder, 'id'>
-    )> }
+      & Pick<Sketch, 'id' | 'updatedAt'>
+    )>> }
   )> }
 );
 
@@ -16410,14 +16437,10 @@ export type UpdateTocItemsParentMutation = (
     { __typename?: 'UpdateSketchTocItemParentResults' }
     & { folders: Array<Maybe<(
       { __typename?: 'SketchFolder' }
-      & Pick<SketchFolder, 'id'>
+      & Pick<SketchFolder, 'id' | 'folderId' | 'collectionId'>
     )>>, sketches: Array<Maybe<(
       { __typename?: 'Sketch' }
-      & Pick<Sketch, 'id' | 'updatedAt'>
-      & { parentCollection?: Maybe<(
-        { __typename?: 'Sketch' }
-        & Pick<Sketch, 'id' | 'updatedAt'>
-      )> }
+      & Pick<Sketch, 'id' | 'updatedAt' | 'folderId' | 'collectionId'>
     )>>, updatedCollections: Array<Maybe<(
       { __typename?: 'Sketch' }
       & Pick<Sketch, 'id' | 'updatedAt'>
@@ -20877,20 +20900,13 @@ export const UpdateSketchDocument = /*#__PURE__*/ gql`
   }
 }
     ${SketchCrudResponseFragmentDoc}`;
-export const DeleteSketchDocument = /*#__PURE__*/ gql`
-    mutation DeleteSketch($id: Int!) {
-  deleteSketch(input: {id: $id}) {
-    sketch {
+export const DeleteSketchTocItemsDocument = /*#__PURE__*/ gql`
+    mutation DeleteSketchTocItems($items: [UpdateTocItemParentInput]!) {
+  deleteSketchTocItems(items: $items) {
+    deletedItems
+    updatedCollections {
       id
-    }
-  }
-}
-    `;
-export const DeleteSketchFolderDocument = /*#__PURE__*/ gql`
-    mutation DeleteSketchFolder($id: Int!) {
-  deleteSketchFolder(input: {id: $id}) {
-    sketchFolder {
-      id
+      updatedAt
     }
   }
 }
@@ -20921,14 +20937,14 @@ export const UpdateTocItemsParentDocument = /*#__PURE__*/ gql`
   ) {
     folders {
       id
+      folderId
+      collectionId
     }
     sketches {
       id
       updatedAt
-      parentCollection {
-        id
-        updatedAt
-      }
+      folderId
+      collectionId
     }
     updatedCollections {
       id
@@ -22145,8 +22161,7 @@ export const namedOperations = {
     CreateSketchFolder: 'CreateSketchFolder',
     CreateSketch: 'CreateSketch',
     UpdateSketch: 'UpdateSketch',
-    DeleteSketch: 'DeleteSketch',
-    DeleteSketchFolder: 'DeleteSketchFolder',
+    DeleteSketchTocItems: 'DeleteSketchTocItems',
     RenameFolder: 'RenameFolder',
     UpdateTocItemsParent: 'UpdateTocItemsParent',
     CopyTocItem: 'CopyTocItem',

--- a/packages/client/src/generated/queries.ts
+++ b/packages/client/src/generated/queries.ts
@@ -769,6 +769,8 @@ export type CopySketchTocItemResults = {
   folders?: Maybe<Array<SketchFolder>>;
   parentId: Scalars['Int'];
   sketches?: Maybe<Array<Sketch>>;
+  /** Returns the parent collection (if exists) so that the client can select an updated updatedAt */
+  updatedCollection?: Maybe<Sketch>;
 };
 
 /** All input for the create `Basemap` mutation. */
@@ -3441,6 +3443,11 @@ export type DeleteSketchPayload = {
   user?: Maybe<User>;
 };
 
+export type DeleteSketchTocItemsResults = {
+  __typename?: 'DeleteSketchTocItemsResults';
+  updatedCollections: Array<Maybe<Sketch>>;
+};
+
 /** All input for the `deleteSurveyByNodeId` mutation. */
 export type DeleteSurveyByNodeIdInput = {
   /**
@@ -5893,6 +5900,8 @@ export type Mutation = {
   deleteSketchFolder?: Maybe<DeleteSketchFolderPayload>;
   /** Deletes a single `SketchFolder` using its globally unique id. */
   deleteSketchFolderByNodeId?: Maybe<DeleteSketchFolderPayload>;
+  /** TODO: implement mutation and result resolvers */
+  deleteSketchTocItems?: Maybe<DeleteSketchTocItemsResults>;
   /** Deletes a single `Survey` using a unique key. */
   deleteSurvey?: Maybe<DeleteSurveyPayload>;
   /** Deletes a single `Survey` using its globally unique id. */
@@ -6159,6 +6168,8 @@ export type Mutation = {
   /** Updates a single `SketchFolder` using its globally unique id and a patch. */
   updateSketchFolderByNodeId?: Maybe<UpdateSketchFolderPayload>;
   updateSketchParent?: Maybe<UpdateSketchParentPayload>;
+  /** TODO: implement mutation and result resolvers */
+  updateSketchTocItemParent?: Maybe<UpdateSketchTocItemParentResults>;
   /** Updates a single `Survey` using a unique key and a patch. */
   updateSurvey?: Maybe<UpdateSurveyPayload>;
   /** Updates a single `Survey` using its globally unique id and a patch. */
@@ -6755,6 +6766,12 @@ export type MutationDeleteSketchFolderArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationDeleteSketchFolderByNodeIdArgs = {
   input: DeleteSketchFolderByNodeIdInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationDeleteSketchTocItemsArgs = {
+  items: Array<Maybe<UpdateTocItemParentInput>>;
 };
 
 
@@ -7420,6 +7437,14 @@ export type MutationUpdateSketchFolderByNodeIdArgs = {
 /** The root mutation type which contains root level fields which mutate data. */
 export type MutationUpdateSketchParentArgs = {
   input: UpdateSketchParentInput;
+};
+
+
+/** The root mutation type which contains root level fields which mutate data. */
+export type MutationUpdateSketchTocItemParentArgs = {
+  collectionId?: Maybe<Scalars['Int']>;
+  folderId?: Maybe<Scalars['Int']>;
+  tocItems: Array<Maybe<UpdateTocItemParentInput>>;
 };
 
 
@@ -12908,6 +12933,13 @@ export type UpdateSketchParentPayload = {
   user?: Maybe<User>;
 };
 
+export type UpdateSketchTocItemParentResults = {
+  __typename?: 'UpdateSketchTocItemParentResults';
+  folders: Array<Maybe<SketchFolder>>;
+  sketches: Array<Maybe<Sketch>>;
+  updatedCollections: Array<Maybe<Sketch>>;
+};
+
 /** All input for the `updateSurveyByNodeId` mutation. */
 export type UpdateSurveyByNodeIdInput = {
   /**
@@ -13180,6 +13212,11 @@ export type UpdateTableOfContentsItemPayload = {
 /** The output of our update `TableOfContentsItem` mutation. */
 export type UpdateTableOfContentsItemPayloadTableOfContentsItemEdgeArgs = {
   orderBy?: Maybe<Array<TableOfContentsItemsOrderBy>>;
+};
+
+export type UpdateTocItemParentInput = {
+  id: Scalars['Int'];
+  type: SketchChildType;
 };
 
 /** All input for the `updateTopicByNodeId` mutation. */
@@ -16360,39 +16397,31 @@ export type GetSketchForEditingQuery = (
   )> }
 );
 
-export type UpdateSketchFolderParentMutationVariables = Exact<{
-  id: Scalars['Int'];
+export type UpdateTocItemsParentMutationVariables = Exact<{
   folderId?: Maybe<Scalars['Int']>;
   collectionId?: Maybe<Scalars['Int']>;
+  tocItems: Array<Maybe<UpdateTocItemParentInput>> | Maybe<UpdateTocItemParentInput>;
 }>;
 
 
-export type UpdateSketchFolderParentMutation = (
+export type UpdateTocItemsParentMutation = (
   { __typename?: 'Mutation' }
-  & { updateSketchFolder?: Maybe<(
-    { __typename?: 'UpdateSketchFolderPayload' }
-    & { sketchFolder?: Maybe<(
+  & { updateSketchTocItemParent?: Maybe<(
+    { __typename?: 'UpdateSketchTocItemParentResults' }
+    & { folders: Array<Maybe<(
       { __typename?: 'SketchFolder' }
-      & Pick<SketchFolder, 'id' | 'folderId' | 'collectionId'>
-    )> }
-  )> }
-);
-
-export type UpdateSketchParentMutationVariables = Exact<{
-  id: Scalars['Int'];
-  folderId?: Maybe<Scalars['Int']>;
-  collectionId?: Maybe<Scalars['Int']>;
-}>;
-
-
-export type UpdateSketchParentMutation = (
-  { __typename?: 'Mutation' }
-  & { updateSketchParent?: Maybe<(
-    { __typename?: 'UpdateSketchParentPayload' }
-    & { sketch?: Maybe<(
+      & Pick<SketchFolder, 'id'>
+    )>>, sketches: Array<Maybe<(
       { __typename?: 'Sketch' }
-      & Pick<Sketch, 'id' | 'folderId' | 'collectionId'>
-    )> }
+      & Pick<Sketch, 'id' | 'updatedAt'>
+      & { parentCollection?: Maybe<(
+        { __typename?: 'Sketch' }
+        & Pick<Sketch, 'id' | 'updatedAt'>
+      )> }
+    )>>, updatedCollections: Array<Maybe<(
+      { __typename?: 'Sketch' }
+      & Pick<Sketch, 'id' | 'updatedAt'>
+    )>> }
   )> }
 );
 
@@ -16421,38 +16450,6 @@ export type SketchReportingDetailsQuery = (
   )> }
 );
 
-export type CopySketchMutationVariables = Exact<{
-  id: Scalars['Int'];
-}>;
-
-
-export type CopySketchMutation = (
-  { __typename?: 'Mutation' }
-  & { copySketch?: Maybe<(
-    { __typename?: 'CopySketchPayload' }
-    & { sketch?: Maybe<(
-      { __typename?: 'Sketch' }
-      & SketchTocDetailsFragment
-    )> }
-  )> }
-);
-
-export type CopySketchFolderMutationVariables = Exact<{
-  id: Scalars['Int'];
-}>;
-
-
-export type CopySketchFolderMutation = (
-  { __typename?: 'Mutation' }
-  & { copySketchFolder?: Maybe<(
-    { __typename?: 'CopySketchFolderPayload' }
-    & { sketchFolder?: Maybe<(
-      { __typename?: 'SketchFolder' }
-      & SketchFolderDetailsFragment
-    )> }
-  )> }
-);
-
 export type CopyTocItemMutationVariables = Exact<{
   id: Scalars['Int'];
   type: SketchChildType;
@@ -16470,7 +16467,10 @@ export type CopyTocItemMutation = (
     )>>, sketches?: Maybe<Array<(
       { __typename?: 'Sketch' }
       & SketchTocDetailsFragment
-    )>> }
+    )>>, updatedCollection?: Maybe<(
+      { __typename?: 'Sketch' }
+      & Pick<Sketch, 'id' | 'updatedAt'>
+    )> }
   )> }
 );
 
@@ -20912,28 +20912,27 @@ export const GetSketchForEditingDocument = /*#__PURE__*/ gql`
   }
 }
     ${SketchEditorModalDetailsFragmentDoc}`;
-export const UpdateSketchFolderParentDocument = /*#__PURE__*/ gql`
-    mutation UpdateSketchFolderParent($id: Int!, $folderId: Int, $collectionId: Int) {
-  updateSketchFolder(
-    input: {id: $id, patch: {folderId: $folderId, collectionId: $collectionId}}
+export const UpdateTocItemsParentDocument = /*#__PURE__*/ gql`
+    mutation UpdateTocItemsParent($folderId: Int, $collectionId: Int, $tocItems: [UpdateTocItemParentInput]!) {
+  updateSketchTocItemParent(
+    folderId: $folderId
+    collectionId: $collectionId
+    tocItems: $tocItems
   ) {
-    sketchFolder {
+    folders {
       id
-      folderId
-      collectionId
     }
-  }
-}
-    `;
-export const UpdateSketchParentDocument = /*#__PURE__*/ gql`
-    mutation UpdateSketchParent($id: Int!, $folderId: Int, $collectionId: Int) {
-  updateSketchParent(
-    input: {id: $id, folderId: $folderId, collectionId: $collectionId}
-  ) {
-    sketch {
+    sketches {
       id
-      folderId
-      collectionId
+      updatedAt
+      parentCollection {
+        id
+        updatedAt
+      }
+    }
+    updatedCollections {
+      id
+      updatedAt
     }
   }
 }
@@ -20970,24 +20969,6 @@ export const SketchReportingDetailsDocument = /*#__PURE__*/ gql`
   }
 }
     `;
-export const CopySketchDocument = /*#__PURE__*/ gql`
-    mutation CopySketch($id: Int!) {
-  copySketch(input: {sketchId: $id}) {
-    sketch {
-      ...SketchTocDetails
-    }
-  }
-}
-    ${SketchTocDetailsFragmentDoc}`;
-export const CopySketchFolderDocument = /*#__PURE__*/ gql`
-    mutation CopySketchFolder($id: Int!) {
-  copySketchFolder(input: {folderId: $id}) {
-    sketchFolder {
-      ...SketchFolderDetails
-    }
-  }
-}
-    ${SketchFolderDetailsFragmentDoc}`;
 export const CopyTocItemDocument = /*#__PURE__*/ gql`
     mutation CopyTocItem($id: Int!, $type: SketchChildType!) {
   copySketchTocItem(id: $id, type: $type) {
@@ -20998,6 +20979,10 @@ export const CopyTocItemDocument = /*#__PURE__*/ gql`
       ...SketchTocDetails
     }
     parentId
+    updatedCollection {
+      id
+      updatedAt
+    }
   }
 }
     ${SketchFolderDetailsFragmentDoc}
@@ -22163,10 +22148,7 @@ export const namedOperations = {
     DeleteSketch: 'DeleteSketch',
     DeleteSketchFolder: 'DeleteSketchFolder',
     RenameFolder: 'RenameFolder',
-    UpdateSketchFolderParent: 'UpdateSketchFolderParent',
-    UpdateSketchParent: 'UpdateSketchParent',
-    CopySketch: 'CopySketch',
-    CopySketchFolder: 'CopySketchFolder',
+    UpdateTocItemsParent: 'UpdateTocItemsParent',
     CopyTocItem: 'CopyTocItem',
     CreateSurvey: 'CreateSurvey',
     UpdateSurveyBaseSettings: 'UpdateSurveyBaseSettings',

--- a/packages/client/src/projects/Sketches/SketchReportWindow.tsx
+++ b/packages/client/src/projects/Sketches/SketchReportWindow.tsx
@@ -71,6 +71,7 @@ export default function SketchReportWindow({
           // eslint-disable-next-line i18next/no-literal-string
           `/sketches/${sketchId}.geojson.json?reporting_access_token=${reportingAccessToken}`
         );
+        console.log("updatedAt", data?.sketch?.updatedAt);
         const initMessage = {
           type: "SeaSketchReportingMessageEventType",
           client: data?.sketchClass?.geoprocessingClientName,

--- a/packages/client/src/projects/Sketches/SketchReportWindow.tsx
+++ b/packages/client/src/projects/Sketches/SketchReportWindow.tsx
@@ -71,7 +71,6 @@ export default function SketchReportWindow({
           // eslint-disable-next-line i18next/no-literal-string
           `/sketches/${sketchId}.geojson.json?reporting_access_token=${reportingAccessToken}`
         );
-        console.log("updatedAt", data?.sketch?.updatedAt);
         const initMessage = {
           type: "SeaSketchReportingMessageEventType",
           client: data?.sketchClass?.geoprocessingClientName,

--- a/packages/client/src/projects/Sketches/useUpdateSketchTableOfContentsItem.ts
+++ b/packages/client/src/projects/Sketches/useUpdateSketchTableOfContentsItem.ts
@@ -1,42 +1,32 @@
 import { useCallback } from "react";
 import { useGlobalErrorHandler } from "../../components/GlobalErrorHandler";
 import {
-  useUpdateSketchFolderParentMutation,
-  useUpdateSketchParentMutation,
+  SketchChildType,
+  UpdateTocItemParentInput,
+  useUpdateTocItemsParentMutation,
 } from "../../generated/graphql";
 
 export default function useUpdateSketchTableOfContentsDraggable() {
   const onError = useGlobalErrorHandler();
-  const [mutateFolder] = useUpdateSketchFolderParentMutation({
+  const [mutate] = useUpdateTocItemsParentMutation({
     onError,
     optimisticResponse: (data) => {
       return {
         __typename: "Mutation",
-        updateSketchFolder: {
-          __typename: "UpdateSketchFolderPayload",
-          sketchFolder: {
-            __typename: "SketchFolder",
-            id: data.id,
-            folderId: data.folderId,
-            collectionId: data.collectionId,
-          },
-        },
-      };
-    },
-  });
-  const [mutateSketch] = useUpdateSketchParentMutation({
-    onError,
-    optimisticResponse: (data) => {
-      return {
-        __typename: "Mutation",
-        updateSketchParent: {
-          __typename: "UpdateSketchParentPayload",
-          sketch: {
-            __typename: "Sketch",
-            id: data.id,
-            folderId: data.folderId,
-            collectionId: data.collectionId,
-          },
+        updateSketchTocItemParent: {
+          __typename: "UpdateSketchTocItemParentResults",
+          folders: ((data.tocItems as UpdateTocItemParentInput[] | null) || [])
+            .filter((i) => i.type === SketchChildType.SketchFolder)
+            .map((i) => ({
+              id: i.id,
+            })),
+          sketches: ((data.tocItems as UpdateTocItemParentInput[] | null) || [])
+            .filter((i) => i.type === SketchChildType.Sketch)
+            .map((i) => ({
+              id: i.id,
+              updatedAt: new Date().toString(),
+            })),
+          updatedCollections: [],
         },
       };
     },
@@ -47,15 +37,19 @@ export default function useUpdateSketchTableOfContentsDraggable() {
       id: number,
       patch: { folderId?: number | null; collectionId?: number | null }
     ) => {
-      return mutateFolder({
+      return mutate({
         variables: {
-          id: id,
-          folderId: patch.folderId,
-          collectionId: patch.collectionId,
+          tocItems: [
+            {
+              id: id,
+              type: SketchChildType.SketchFolder,
+            },
+          ],
+          ...patch,
         },
       });
     },
-    [mutateFolder]
+    [mutate]
   );
 
   const dropSketch = useCallback(
@@ -63,15 +57,19 @@ export default function useUpdateSketchTableOfContentsDraggable() {
       id: number,
       patch: { folderId?: number | null; collectionId?: number | null }
     ) => {
-      return mutateSketch({
+      return mutate({
         variables: {
-          id: id,
-          folderId: patch.folderId,
-          collectionId: patch.collectionId,
+          tocItems: [
+            {
+              id: id,
+              type: SketchChildType.Sketch,
+            },
+          ],
+          ...patch,
         },
       });
     },
-    [mutateSketch]
+    [mutate]
   );
 
   return { dropFolder, dropSketch };

--- a/packages/client/src/projects/Sketches/useUpdateSketchTableOfContentsItem.ts
+++ b/packages/client/src/projects/Sketches/useUpdateSketchTableOfContentsItem.ts
@@ -18,13 +18,19 @@ export default function useUpdateSketchTableOfContentsDraggable() {
           folders: ((data.tocItems as UpdateTocItemParentInput[] | null) || [])
             .filter((i) => i.type === SketchChildType.SketchFolder)
             .map((i) => ({
+              __typename: "SketchFolder",
               id: i.id,
+              folderId: data.folderId,
+              collectionId: data.collectionId,
             })),
           sketches: ((data.tocItems as UpdateTocItemParentInput[] | null) || [])
             .filter((i) => i.type === SketchChildType.Sketch)
             .map((i) => ({
+              __typename: "Sketch",
               id: i.id,
               updatedAt: new Date().toString(),
+              folderId: data.folderId,
+              collectionId: data.collectionId,
             })),
           updatedCollections: [],
         },

--- a/packages/client/src/queries/Sketching.graphql
+++ b/packages/client/src/queries/Sketching.graphql
@@ -115,18 +115,12 @@ mutation UpdateSketch(
   }
 }
 
-mutation DeleteSketch($id: Int!) {
-  deleteSketch(input: { id: $id }) {
-    sketch {
+mutation DeleteSketchTocItems($items: [UpdateTocItemParentInput]!) {
+  deleteSketchTocItems(items: $items) {
+    deletedItems
+    updatedCollections {
       id
-    }
-  }
-}
-
-mutation DeleteSketchFolder($id: Int!) {
-  deleteSketchFolder(input: { id: $id }) {
-    sketchFolder {
-      id
+      updatedAt
     }
   }
 }
@@ -170,14 +164,14 @@ mutation UpdateTocItemsParent(
   ) {
     folders {
       id
+      folderId
+      collectionId
     }
     sketches {
       id
       updatedAt
-      parentCollection {
-        id
-        updatedAt
-      }
+      folderId
+      collectionId
     }
     updatedCollections {
       id

--- a/packages/client/src/queries/Sketching.graphql
+++ b/packages/client/src/queries/Sketching.graphql
@@ -158,33 +158,30 @@ query GetSketchForEditing($id: Int!) {
   }
 }
 
-mutation UpdateSketchFolderParent(
-  $id: Int!
+mutation UpdateTocItemsParent(
   $folderId: Int
   $collectionId: Int
+  $tocItems: [UpdateTocItemParentInput]!
 ) {
-  updateSketchFolder(
-    input: {
-      id: $id
-      patch: { folderId: $folderId, collectionId: $collectionId }
-    }
+  updateSketchTocItemParent(
+    folderId: $folderId
+    collectionId: $collectionId
+    tocItems: $tocItems
   ) {
-    sketchFolder {
+    folders {
       id
-      folderId
-      collectionId
     }
-  }
-}
-
-mutation UpdateSketchParent($id: Int!, $folderId: Int, $collectionId: Int) {
-  updateSketchParent(
-    input: { id: $id, folderId: $folderId, collectionId: $collectionId }
-  ) {
-    sketch {
+    sketches {
       id
-      folderId
-      collectionId
+      updatedAt
+      parentCollection {
+        id
+        updatedAt
+      }
+    }
+    updatedCollections {
+      id
+      updatedAt
     }
   }
 }
@@ -220,22 +217,6 @@ query SketchReportingDetails($id: Int!, $sketchClassId: Int!) {
   }
 }
 
-mutation CopySketch($id: Int!) {
-  copySketch(input: { sketchId: $id }) {
-    sketch {
-      ...SketchTocDetails
-    }
-  }
-}
-
-mutation CopySketchFolder($id: Int!) {
-  copySketchFolder(input: { folderId: $id }) {
-    sketchFolder {
-      ...SketchFolderDetails
-    }
-  }
-}
-
 mutation CopyTocItem($id: Int!, $type: SketchChildType!) {
   copySketchTocItem(id: $id, type: $type) {
     folders {
@@ -245,6 +226,10 @@ mutation CopyTocItem($id: Int!, $type: SketchChildType!) {
       ...SketchTocDetails
     }
     parentId
+    updatedCollection {
+      id
+      updatedAt
+    }
   }
 }
 


### PR DESCRIPTION
When child sketches or folders are added, removed, or updated, the parent collection should get an updated updatedAt timestamp. This is enforced on the DB-side and also exposed in appropriate Graphql mutation results so that the Apollo client cache can be updated as appropriate.