### PR TITLE
Add agent guidance for safe TypeScript type guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,12 @@
   - Don't ever modify json files in packages/client/src/lang/ -- Those are automatically generated!
 - **Typescript features**
   - Our graphql codegen process uses an older babel system to parse code and extract gql strings. Don't use `import type` syntax anywhere in the client, or in code that is imported by it or there will be trouble. Check the `GraphQL:codegen` terminal task for errors caused by usage of this syntax.
+- **Type guards and untrusted JSON**
+  - Fields typed as GraphQL `JSON` (for example `geostats`) are untrusted at runtime. Narrow them with type guards; do not assume the declared TS shape is present.
+  - Type guards (`isX` / `value is Foo`) should take `unknown` (not `any`, and not only the success-case union). Handle `null` and `undefined` before reading properties.
+  - Prefer `typeof`, `Array.isArray`, and the `in` operator to narrow. Do **not** write `(value as Foo).prop` as the first step of a type guard — that assertion silences `strictNullChecks` and can throw at runtime (see the Interactivity Settings / `isRasterInfo` crash).
+  - When adding or editing a type guard, add a few unit tests for `null`, `undefined`, non-objects, and a valid example. Sibling guards in the same module should follow the same defensive pattern.
+  - Good reference implementations: `isGeostatsLayer` in `packages/geostats-types`, `isRasterSource` in `packages/client/src/reports/widgets/ClassTableRows.ts`.
 
 ## 📄 Example: Creating a New React Component (including i18n)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an AGENTS.md convention for writing TypeScript type guards over untrusted GraphQL `JSON` (e.g. `geostats`).

This follows the Interactivity Settings crash fixed in `966ad804`, where `isRasterInfo(undefined)` threw because the guard used `(info as RasterInfo).bands` without a null check. TypeScript did not catch it because of `| any` plus a type assertion inside the predicate.

## Guidance added

- Type guards should take `unknown`, not `any` / success-case-only unions
- Null/undefined must be handled before property access
- Prefer `typeof` / `in` / `Array.isArray`; do not cast-then-dereference first
- Add cheap unit tests for null/undefined/non-objects when touching guards
- Point to good in-repo examples (`isGeostatsLayer`, `isRasterSource`)

## Out of scope

Repo-wide `@typescript-eslint/no-explicit-any` is intentionally not enabled here — the client has ~1000 existing violations. A scoped lint pass can follow separately if desired.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fc498-7049-7774-988c-d15df9fc435c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fc498-7049-7774-988c-d15df9fc435c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

