### PR TITLE
Upgrade GitHub Actions and improve npm caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,14 +29,12 @@ jobs:
       client: ${{ steps.changes.outputs.client }}
       build_label: ${{ steps.short_sha.outputs.sha }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - id: short_sha
-        run: |
-          echo `git rev-parse HEAD`
-          echo "::set-output name=sha::`git rev-parse --short HEAD`"
-      - uses: actions/github-script@v4
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+      - uses: actions/github-script@v9
         id: deployments
         with:
           script: |
@@ -63,7 +61,7 @@ jobs:
               console.log('base:', mostRecentActiveDeployment.commitOid);
             }
             console.log('ref:', '${{github.ref}}');
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v4
         name: get changed packages
         id: changes
         with:
@@ -92,14 +90,13 @@ jobs:
       - detect_changes
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
       - name: Install unbuffer command
-        run: |
-          sudo apt-get install expect
+        run: sudo apt-get install expect
       - name: Find current maintenance bastion task
         id: maintenance
         run: |
@@ -140,23 +137,22 @@ jobs:
       - detect_changes
       - run_migrations
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: "23"
-          cache: "npm"
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
       - name: Install CDK
-        run: |
-          npm install -g aws-cdk typescript@5.5.3
+        run: npm install -g aws-cdk typescript@5.5.3
       - name: Install dependencies
-        run: |
-          npx lerna@6.6.2 bootstrap --scope=infra
+        run: npx lerna@6.6.2 bootstrap --scope=infra
       - name: Deploy server
         working-directory: ./packages/infra
         env:
@@ -190,8 +186,7 @@ jobs:
           GOOGLE_MAPS_2D_TILE_API_KEY: ${{ secrets.GOOGLE_MAPS_2D_TILE_API_KEY }}
           CF_AIG_TOKEN: ${{ secrets.CF_AIG_TOKEN }}
           CF_AIG_URL: ${{ secrets.CF_AIG_URL }}
-        run: |
-          cdk deploy --require-approval never -e SeaSketchGraphQLServer
+        run: cdk deploy --require-approval never -e SeaSketchGraphQLServer
   api_ready_gate:
     name: API ready for client
     runs-on: ubuntu-latest
@@ -226,10 +221,10 @@ jobs:
             fi
             echo "API deploy not required (deploy_server=$server_result); proceeding to live schema validation."
           fi
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: "23"
+          node-version-file: ".nvmrc"
           cache: npm
           cache-dependency-path: packages/client/graphql-validate/package-lock.json
       # Isolated package with only graphql — avoids private @seasketch/* deps in
@@ -260,14 +255,14 @@ jobs:
       - detect_changes
       - api_ready_gate
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: "23"
-          cache: "npm"
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
       - name: Install dependencies
-        run: |
-          npx lerna@6.6.2 bootstrap --ci
+        run: npx lerna@6.6.2 bootstrap --ci
       - name: Build client
         working-directory: ./packages/client
         env:
@@ -283,74 +278,26 @@ jobs:
           REACT_APP_CLOUDFRONT_DOCS_DISTRO: ${{ secrets.REACT_APP_CLOUDFRONT_DOCS_DISTRO }}
           REACT_APP_CLOUDFLARE_IMAGES_ENDPOINT: ${{ secrets.REACT_APP_CLOUDFLARE_IMAGES_ENDPOINT }}
           REACT_APP_GOOGLE_MAPS_2D_TILE_API_KEY: ${{ secrets.REACT_APP_GOOGLE_MAPS_2D_TILE_API_KEY }}
-        run: |
-          CI=false npm run build
+        run: CI=false npm run build
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-      # - name: Update deployment
-      #   working-directory: ./packages/client
-      #   env:
-      #     S3_BUCKET: ${{ secrets.S3_CLIENT_BUCKET}}
-      #   run: |
-      #     ls -l
-      #     if [[ -z "$S3_BUCKET" ]]; then
-      #       echo "S3_BUCKET could not be found" 1>&2
-      #       exit 1
-      #     fi
-
-      #     echo "Uploading files to $S3_BUCKET..."
-      #     aws s3 sync build $S3_BUCKET \
-      #       --acl public-read \
-      #       --cache-control max-age=31536000 \
-      #       --exclude service-worker.js \
-      #       --exclude manifest.json \
-      #       --exclude index.html \
-      #       --delete
-
-      #     echo "Uploading manifest.json"
-      #     aws s3 cp build/manifest.json $S3_BUCKET/manifest.json \
-      #       --metadata-directive REPLACE \
-      #       --cache-control max-age=0,no-cache,no-store,must-revalidate \
-      #       --content-type application/json \
-      #       --acl public-read
-
-      #     echo "Uploading index.html"
-      #     aws s3 cp build/index.html $S3_BUCKET/index.html \
-      #       --metadata-directive REPLACE \
-      #       --cache-control max-age=0,no-cache,no-store,must-revalidate \
-      #       --content-type text/html \
-      #       --acl public-read
-
-      #     echo "Uploading service-worker.js"
-      #     aws s3 cp build/service-worker.js $S3_BUCKET/service-worker.js \
-      #       --metadata-directive REPLACE \
-      #       --cache-control max-age=300 \
-      #       --content-type text/javascript \
-      #       --acl public-read
-
-      #     aws s3 cp build/service-worker.js.map $S3_BUCKET/service-worker.js.map \
-      #       --metadata-directive REPLACE \
-      #       --cache-control max-age=300 \
-      #       --content-type text/javascript \
-      #       --acl public-read
       - name: deploy to cloudflare workers
         working-directory: ./packages/client
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{secrets.CLOUDFLARE_ACCOUNT_ID}}
           CLOUDFLARE_API_TOKEN: ${{secrets.CLOUDFLARE_API_TOKEN}}
-        run: |
-          npx wrangler@4 deploy
+        run: npx wrangler@4 deploy
       - name: Create Sentry release
-        uses: getsentry/action-release@v1
+        uses: getsentry/action-release@v3
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         with:
           environment: production
-          version: ${{ needs.detect_changes.outputs.build_label }}
+          release: ${{ needs.detect_changes.outputs.build_label }}
           sourcemaps: packages/client/build/static/js/

--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -9,14 +9,14 @@ jobs:
       name: preview_client
       url: ${{ steps.wrangler.outputs.preview_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: "23"
-          cache: "npm"
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
       - name: Install dependencies
-        run: |
-          npx lerna@6.6.2 bootstrap --ci
+        run: npx lerna@6.6.2 bootstrap --ci
       - name: Build client
         working-directory: ./packages/client
         env:
@@ -31,8 +31,7 @@ jobs:
           REACT_APP_SENTRY_DSN: ${{ secrets.REACT_APP_SENTRY_DSN }}
           REACT_APP_CLOUDFRONT_DOCS_DISTRO: ${{ secrets.REACT_APP_CLOUDFRONT_DOCS_DISTRO }}
           REACT_APP_CLOUDFLARE_IMAGES_ENDPOINT: ${{ secrets.REACT_APP_CLOUDFLARE_IMAGES_ENDPOINT }}
-        run: |
-          CI=false npm run build
+        run: CI=false npm run build
       - name: upload cloudflare workers version preview
         id: wrangler
         working-directory: ./packages/client

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,11 @@
 name: Unit Tests
 on: [push]
+
+permissions:
+  contents: read
+  checks: write
+  actions: read
+
 jobs:
   test-server:
     name: Test GraphQL API Server
@@ -16,40 +22,37 @@ jobs:
         ports:
           - "6379:6379"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: "23"
-          cache: "npm"
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
       - name: Install dependencies
-        run: |
-          npx lerna@6.6.2 bootstrap --ci
-      # - name: Setup tmate session
-      #   uses: mxschmitt/action-tmate@v3
+        run: npx lerna@6.6.2 bootstrap --ci
       - name: Build API
         working-directory: ./packages/api
-        run: |
-          npm run build
+        run: npm run build
       - name: Init docker db
         working-directory: ./packages/api
         env:
           TEST_DB: postgres://postgres:password@localhost:5432/
-        run: |
-          node tests/init_dockerdb.js
+        run: node tests/init_dockerdb.js
       - name: Run Tests
         working-directory: ./packages/api
-        run: |
-          npx jest --ci --reporters=default --reporters=jest-junit
+        run: npx jest --ci --reporters=default --reporters=jest-junit
         env:
           TEST_DB: postgres://postgres:password@localhost:5432/
           SES_EMAIL_SOURCE: do-not-reply@seasketch.org
-      - uses: IgnusG/jest-report-action@v2.3.3
-        if: always()
+      - name: API Test Report
+        uses: dorny/test-reporter@v3
+        if: ${{ !cancelled() }}
         with:
-          access-token: ${{ secrets.GITHUB_TOKEN }}
-          working-directory: ./packages/api
-          check-name: API Test Output
-          run-name: Test GraphQL API Server
+          name: API Test Output
+          path: packages/api/junit.xml
+          reporter: jest-junit
+          fail-on-error: false
+
   database-drift:
     name: Check for schema and generated code drift
     runs-on: ubuntu-latest
@@ -65,18 +68,17 @@ jobs:
         ports:
           - "6379:6379"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: "23"
-          cache: "npm"
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
       - name: Install dependencies
-        run: |
-          npx lerna@6.6.2 bootstrap --ci
+        run: npx lerna@6.6.2 bootstrap --ci
       - name: Build API
         working-directory: ./packages/api
-        run: |
-          npm run build
+        run: npm run build
       - name: Initialize database
         working-directory: ./packages/api
         env:
@@ -102,48 +104,48 @@ jobs:
         run: |
           npx graphql-codegen --config codegen.yml
           git diff --exit-code ./src/generated/graphql.ts
+
   test-client:
     name: Test React Client
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: "23"
-          cache: "npm"
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
       - name: Install dependencies
-        run: |
-          npx lerna@6.6.2 bootstrap --ci
+        run: npx lerna@6.6.2 bootstrap --ci
       - name: Test client
         working-directory: ./packages/client
         env:
           SKIP_PREFLIGHT_CHECK: true
           REACT_APP_GRAPHQL_ENDPOINT: http://localhost:3857/graphql
-        run: |
-          npm run test -- --ci --testResultsProcessor="jest-junit" --watchAll=false
-      - uses: IgnusG/jest-report-action@v2.3.3
-        if: always()
+        run: npm run test -- --ci --testResultsProcessor="jest-junit" --watchAll=false
+      - name: React Client Test Report
+        uses: dorny/test-reporter@v3
+        if: ${{ !cancelled() }}
         with:
-          access-token: ${{ secrets.GITHUB_TOKEN }}
-          working-directory: ./packages/client
-          check-name: React Client Test Output
-          run-name: Test React Client
+          name: React Client Test Output
+          path: packages/client/junit.xml
+          reporter: jest-junit
+          fail-on-error: false
+
   build-client:
     name: Build React Client
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
-          node-version: "23"
-          cache: "npm"
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: "**/package-lock.json"
       - id: short_sha
-        run: |
-          echo `git rev-parse HEAD`
-          echo "::set-output name=sha::`git rev-parse --short HEAD`"
+        run: echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
       - name: Install dependencies
-        run: |
-          npx lerna@6.6.2 bootstrap --ci
+        run: npx lerna@6.6.2 bootstrap --ci
       - name: Build client
         working-directory: ./packages/client
         env:
@@ -155,233 +157,4 @@ jobs:
           REACT_APP_MAPBOX_ACCESS_TOKEN: abc123
           REACT_APP_GRAPHQL_ENDPOINT: https://example.com/graphql
           REACT_APP_BUILD: ${{ steps.short_sha.outputs.sha }}
-        run: |
-          NODE_OPTIONS=--openssl-legacy-provider CI=false npm run build
-  # integration-tests:
-  #   name: Cypress Integration Tests
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 60
-  #   # container: cypress/browsers:node16.5.0-chrome94-ff93
-  #   services:
-  #     postgres:
-  #       image: underbluewaters/seasketch_db_base
-  #       ports:
-  #         - "5432:5432"
-  #       env:
-  #         POSTGRES_PASSWORD: password
-  #     redis:
-  #       image: "redis:alpine"
-  #       ports:
-  #         - "6379:6379"
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-node@v2
-  #       with:
-  #         node-version: "18.6"
-  #     - id: short_sha
-  #       run: |
-  #         echo `git rev-parse HEAD`
-  #         echo "::set-output name=sha::`git rev-parse --short HEAD`"
-  #     - name: Cache node modules
-  #       uses: actions/cache@v2
-  #       env:
-  #         cache-name: cache-integration-node-modules
-  #       with:
-  #         # npm cache files are stored in `~/.npm` on Linux/macOS
-  #         path: |
-  #           node_modules
-  #           */*/node_modules
-  #           ~/.npm
-  #           ~/.cache/Cypress
-  #         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-build-${{ env.cache-name }}-
-  #           ${{ runner.os }}-build-
-  #           ${{ runner.os }}-
-  #     - name: Install
-  #       run: |
-  #         npm install
-  #         npm install -g lerna
-  #         npm install serve -g
-  #         lerna bootstrap
-  #     - name: Init docker db
-  #       working-directory: ./packages/api
-  #       env:
-  #         TEST_DB: postgres://postgres:password@localhost:5432/
-  #         DATABASE_URL: postgres://postgres:password@localhost:5432/seasketch
-  #       run: |
-  #         node tests/init_dockerdb.js
-  #         npm run db:migrate
-  #     - name: Start API Server
-  #       working-directory: ./packages/api
-  #       env:
-  #         DATABASE_URL: postgres://graphile:password@localhost:5432/seasketch
-  #         ADMIN_DATABASE_URL: postgres://postgres:password@localhost:5432/seasketch
-  #         AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
-  #         AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
-  #         AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
-  #         JWKS_URI: ${{ secrets.JWKS_URI }}
-  #         JWT_AUD: ${{ secrets.JWT_AUD }}
-  #         JWT_ISS: ${{ secrets.JWT_ISS }}
-  #         PUBLIC_S3_BUCKET: ${{ secrets.PUBLIC_S3_BUCKET }}
-  #         PUBLIC_UPLOADS_DOMAIN: ${{ secrets.PUBLIC_UPLOADS_DOMAIN }}
-  #         S3_REGION: ${{ secrets.S3_REGION }}
-  #         SES_EMAIL_SOURCE: ${{ secrets.SES_EMAIL_SOURCE }}
-  #         UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
-  #         NODE_ENV: staging
-  #         GRAPHILE_WORKER_CONCURRENCY: 5
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         IS_CYPRESS_TEST_ENV: "true"
-  #       run: |
-  #         npm run build
-  #         npm start &
-  #     - name: Start client
-  #       working-directory: ./packages/client
-  #       run: |
-  #         NODE_OPTIONS=--openssl-legacy-provider CI=false npm run build
-  #         serve -s build &
-  #       env:
-  #         SKIP_PREFLIGHT_CHECK: true
-  #         REACT_APP_AUTH0_CLIENT_ID: ${{ secrets.REACT_APP_AUTH0_CLIENT_ID }}
-  #         REACT_APP_AUTH0_DOMAIN: ${{ secrets.REACT_APP_AUTH0_DOMAIN }}
-  #         REACT_APP_AUTH0_SCOPE: ${{ secrets.REACT_APP_AUTH0_SCOPE }}
-  #         REACT_APP_AUTH0_AUDIENCE: ${{ secrets.REACT_APP_AUTH0_AUDIENCE }}
-  #         REACT_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.REACT_APP_MAPBOX_ACCESS_TOKEN }}
-  #         REACT_APP_GRAPHQL_ENDPOINT: http://localhost:3857/graphql
-  #         CYPRESS_BASE_URL: http://localhost:3000
-  #         REACT_APP_BUILD: e2e-tests-${{ steps.short_sha.outputs.sha }}
-  #     - name: Cypress run
-  #       uses: cypress-io/github-action@v2
-  #       with:
-  #         record: true
-  #         browser: chrome
-  #         wait-on: "http://localhost:3000"
-  #         install-command: "true"
-  #         working-directory: ./packages/client
-  #         wait-on-timeout: 240
-  #         config: baseUrl=http://localhost:3000
-  #       env:
-  #         CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORDING_KEY }}
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         CYPRESS_AUTH0_CLIENT_SECRET: ${{ secrets.CYPRESS_AUTH0_CLIENT_SECRET }}
-  #         REACT_APP_AUTH0_CLIENT_ID: ${{ secrets.REACT_APP_AUTH0_CLIENT_ID }}
-  #         REACT_APP_AUTH0_DOMAIN: ${{ secrets.REACT_APP_AUTH0_DOMAIN }}
-  #         REACT_APP_AUTH0_SCOPE: ${{ secrets.REACT_APP_AUTH0_SCOPE }}
-  #         REACT_APP_AUTH0_AUDIENCE: ${{ secrets.REACT_APP_AUTH0_AUDIENCE }}
-  #         REACT_APP_GRAPHQL_ENDPOINT: http://localhost:3857/graphql
-  #         CYPRESS_TEST_DB: postgres://postgres:password@localhost:5432/seasketch
-  #         AUTH0_MANAGEMENT_API_CLIENT_ID: ${{ secrets.AUTH0_MANAGEMENT_API_CLIENT_ID }}
-  #         AUTH0_MANAGEMENT_API_CLIENT_SECRET: ${{ secrets.AUTH0_MANAGEMENT_API_CLIENT_SECRET }}
-  # percy-visual-tests:
-  #   name: Percy Visual Testing
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 60
-  #   # container: cypress/browsers:node16.5.0-chrome94-ff93
-  #   services:
-  #     postgres:
-  #       image: underbluewaters/seasketch_db_base
-  #       ports:
-  #         - "5432:5432"
-  #       env:
-  #         POSTGRES_PASSWORD: password
-  #     redis:
-  #       image: "redis:alpine"
-  #       ports:
-  #         - "6379:6379"
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-node@v2
-  #       with:
-  #         node-version: "18.6"
-  #     - id: short_sha
-  #       run: |
-  #         echo `git rev-parse HEAD`
-  #         echo "::set-output name=sha::`git rev-parse --short HEAD`"
-  #     - name: Cache node modules
-  #       uses: actions/cache@v2
-  #       env:
-  #         cache-name: cache-integration-node-modules
-  #       with:
-  #         # npm cache files are stored in `~/.npm` on Linux/macOS
-  #         path: |
-  #           node_modules
-  #           */*/node_modules
-  #           ~/.npm
-  #           ~/.cache/Cypress
-  #         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-  #         restore-keys: |
-  #           ${{ runner.os }}-build-${{ env.cache-name }}-
-  #           ${{ runner.os }}-build-
-  #           ${{ runner.os }}-
-  #     - name: Install
-  #       run: |
-  #         npm install
-  #         npm install -g lerna
-  #         npm install serve -g
-  #         lerna bootstrap
-  #     - name: Init docker db
-  #       working-directory: ./packages/api
-  #       env:
-  #         TEST_DB: postgres://postgres:password@localhost:5432/
-  #         DATABASE_URL: postgres://postgres:password@localhost:5432/seasketch
-  #       run: |
-  #         node tests/init_dockerdb.js
-  #         npm run db:migrate
-  #     - name: Start API Server
-  #       working-directory: ./packages/api
-  #       env:
-  #         DATABASE_URL: postgres://graphile:password@localhost:5432/seasketch
-  #         ADMIN_DATABASE_URL: postgres://postgres:password@localhost:5432/seasketch
-  #         AUTH0_CLIENT_ID: ${{ secrets.AUTH0_CLIENT_ID }}
-  #         AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
-  #         AUTH0_DOMAIN: ${{ secrets.AUTH0_DOMAIN }}
-  #         HOST: ${{ secrets.HOST }}
-  #         JWKS_URI: ${{ secrets.JWKS_URI }}
-  #         JWT_AUD: ${{ secrets.JWT_AUD }}
-  #         JWT_ISS: ${{ secrets.JWT_ISS }}
-  #         PUBLIC_S3_BUCKET: ${{ secrets.PUBLIC_S3_BUCKET }}
-  #         PUBLIC_UPLOADS_DOMAIN: ${{ secrets.PUBLIC_UPLOADS_DOMAIN }}
-  #         S3_REGION: ${{ secrets.S3_REGION }}
-  #         SES_EMAIL_SOURCE: ${{ secrets.SES_EMAIL_SOURCE }}
-  #         UNSPLASH_KEY: ${{ secrets.UNSPLASH_KEY }}
-  #         NODE_ENV: staging
-  #         GRAPHILE_WORKER_CONCURRENCY: 5
-  #         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  #         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  #         IS_CYPRESS_TEST_ENV: "true"
-  #       run: |
-  #         npm run build
-  #         npm start &
-  #     - name: Start client
-  #       working-directory: ./packages/client
-  #       run: |
-  #         NODE_OPTIONS=--openssl-legacy-provider CI=false npm run build
-  #         serve -s build &
-  #       env:
-  #         SKIP_PREFLIGHT_CHECK: true
-  #         REACT_APP_AUTH0_CLIENT_ID: ${{ secrets.REACT_APP_AUTH0_CLIENT_ID }}
-  #         REACT_APP_AUTH0_DOMAIN: ${{ secrets.REACT_APP_AUTH0_DOMAIN }}
-  #         REACT_APP_AUTH0_SCOPE: ${{ secrets.REACT_APP_AUTH0_SCOPE }}
-  #         REACT_APP_AUTH0_AUDIENCE: ${{ secrets.REACT_APP_AUTH0_AUDIENCE }}
-  #         REACT_APP_MAPBOX_ACCESS_TOKEN: ${{ secrets.REACT_APP_MAPBOX_ACCESS_TOKEN }}
-  #         REACT_APP_GRAPHQL_ENDPOINT: http://localhost:3857/graphql
-  #         CYPRESS_BASE_URL: http://localhost:3000
-  #         REACT_APP_BUILD: e2e-tests-${{ steps.short_sha.outputs.sha }}
-  #     - name: Percy/Cypress Run
-  #       working-directory: ./packages/client
-  #       run: npx @percy/cli exec -- cypress run --record false
-  #       env:
-  #         CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORDING_KEY }}
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         CYPRESS_AUTH0_CLIENT_SECRET: ${{ secrets.CYPRESS_AUTH0_CLIENT_SECRET }}
-  #         REACT_APP_AUTH0_CLIENT_ID: ${{ secrets.REACT_APP_AUTH0_CLIENT_ID }}
-  #         REACT_APP_AUTH0_DOMAIN: ${{ secrets.REACT_APP_AUTH0_DOMAIN }}
-  #         REACT_APP_AUTH0_SCOPE: ${{ secrets.REACT_APP_AUTH0_SCOPE }}
-  #         REACT_APP_AUTH0_AUDIENCE: ${{ secrets.REACT_APP_AUTH0_AUDIENCE }}
-  #         REACT_APP_GRAPHQL_ENDPOINT: http://localhost:3857/graphql
-  #         CYPRESS_TEST_DB: postgres://postgres:password@localhost:5432/seasketch
-  #         PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-  #         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-  #         AUTH0_MANAGEMENT_API_CLIENT_ID: ${{ secrets.AUTH0_MANAGEMENT_API_CLIENT_ID }}
-  #         AUTH0_MANAGEMENT_API_CLIENT_SECRET: ${{ secrets.AUTH0_MANAGEMENT_API_CLIENT_SECRET }}
+        run: NODE_OPTIONS=--openssl-legacy-provider CI=false npm run build


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Maintenance-only update to `.github/workflows/*` — no application code changes.

### Action upgrades
| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | **v7** |
| `actions/setup-node` | v4 | **v7** |
| `actions/github-script` | v4 | **v9** |
| `aws-actions/configure-aws-credentials` | v1 | **v6** |
| `dorny/paths-filter` | v2 | **v4** |
| `getsentry/action-release` | v1 | **v3** (`version` → `release`) |

These remove the Node.js 20 deprecation warnings that were emitted on every CI job (`checkout@v4` / `setup-node@v4` target Node 20 while runners force Node 24).

### Caching / Node setup
- Read Node version from `.nvmrc` via `node-version-file` instead of hardcoding `"23"`.
- Set `cache-dependency-path: "**/package-lock.json"` so the npm cache key covers this Lerna monorepo’s package lockfiles, not only the root lockfile.

### Cleanup
- Replaced deprecated `::set-output` with `$GITHUB_OUTPUT`.
- Replaced abandoned/broken `IgnusG/jest-report-action@v2.3.3` (ENOENT spam on suite names) with `dorny/test-reporter@v3`.
- Removed large blocks of commented-out Cypress/Percy/S3 sync workflow dead code.

### CI verification
[Unit Tests run](https://github.com/seasketch/next/actions/runs/31545391013) on this PR: **all 4 jobs passed**
- Test GraphQL API Server ✅ (554 tests via new reporter)
- Test React Client ✅ (302 passed / 9 skipped)
- Check for schema and generated code drift ✅
- Build React Client ✅

Also confirmed: zero Node.js 20 deprecation warnings; new monorepo-aware npm cache key created and saved (`**/package-lock.json`).

`Preview Client Build` is currently disabled in the repo, and `Create Deployment` is `workflow_dispatch`-only, so those weren’t exercised by this push.

### Not changed
- Deploy job graph / conditions
- Lerna bootstrap install approach
- Application source code

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff315-3303-7ad9-8713-29ea138a2dfa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff315-3303-7ad9-8713-29ea138a2dfa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

